### PR TITLE
Encode the MIR control flow graph into the resulting binary.

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1297,6 +1297,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mkstemp-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1914,7 @@ dependencies = [
  "rustc_errors 0.0.0",
  "rustc_fs_util 0.0.0",
  "rustc_target 0.0.0",
+ "rustc_yk_link 0.0.0",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2201,6 +2210,8 @@ dependencies = [
  "rustc_target 0.0.0",
  "rustc_traits 0.0.0",
  "rustc_typeck 0.0.0",
+ "rustc_yk_link 0.0.0",
+ "rustc_yk_sections 0.0.0",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2470,6 +2481,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc_yk_link"
+version = "0.0.0"
+
+[[package]]
+name = "rustc_yk_sections"
+version = "0.0.0"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mkstemp-rs 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc 0.0.0",
+ "rustc_yk_link 0.0.0",
 ]
 
 [[package]]
@@ -3282,6 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum minifier 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "96c269bb45c39b333392b2b18ad71760b34ac65666591386b0e959ed58b3f474"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+"checksum mkstemp-rs 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab06da7d0a30c709867eb54e757f86b69e3b4dd4ac3c0f9502edec4e077a604e"
 "checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -25,6 +25,7 @@ rustc_apfloat = { path = "../librustc_apfloat" }
 rustc_target = { path = "../librustc_target" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
+rustc_yk_link = { path = "../librustc_yk_link" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -95,6 +95,7 @@ extern crate parking_lot;
 extern crate rustc_errors as errors;
 extern crate rustc_rayon as rayon;
 extern crate rustc_rayon_core as rayon_core;
+extern crate rustc_yk_link;
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
 extern crate syntax_pos;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -24,6 +24,7 @@ use session::config::{OutputType, Lto};
 use util::nodemap::{FxHashMap, FxHashSet};
 use util::common::{duration_to_secs_str, ErrorReported};
 use util::common::ProfileQueriesMsg;
+use rustc_yk_link::YkExtraLinkObject;
 
 use rustc_data_structures::base_n;
 use rustc_data_structures::sync::{self, Lrc, Lock, LockCell, OneThread, Once, RwLock};
@@ -61,6 +62,9 @@ pub mod search_paths;
 /// Represents the data associated with a compilation
 /// session for a single crate.
 pub struct Session {
+    /// A list of additional objects to link in for Yorick support.
+    pub yk_link_objects: RefCell<Vec<YkExtraLinkObject>>,
+
     pub target: config::Config,
     pub host: Target,
     pub opts: config::Options,
@@ -1133,6 +1137,7 @@ pub fn build_session_(
     };
 
     let sess = Session {
+        yk_link_objects: RefCell::new(Vec::new()),
         target: target_cfg,
         host,
         opts: sopts,

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -720,6 +720,15 @@ fn link_natively(sess: &Session,
     if let Some(args) = sess.target.target.options.post_link_args.get(&flavor) {
         cmd.args(args);
     }
+
+    // Link Yorick objects in.
+    if let Ok(_) = env::var("YK_DEBUG_SECTIONS") {
+        if crate_type == config::CrateType::Executable {
+            cmd.arg("-Wl,--no-gc-sections");
+            cmd.args(sess.yk_link_objects.borrow().iter().map(|o| o.path()));
+        }
+    }
+
     for &(ref k, ref v) in &sess.target.target.options.link_env {
         cmd.env(k, v);
     }

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -735,8 +735,7 @@ fn determine_cgu_reuse<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                rx: mpsc::Receiver<Box<dyn Any + Send>>)
-                               -> OngoingCodegen
-{
+                               -> (OngoingCodegen, Arc<DefIdSet>) {
     check_for_rustc_errors_attr(tcx);
 
     if let Some(true) = tcx.sess.opts.debugging_opts.thinlto {
@@ -796,12 +795,12 @@ pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         ongoing_codegen.check_for_errors(tcx.sess);
 
-        return ongoing_codegen;
+        return (ongoing_codegen, Arc::new(DefIdSet()));
     }
 
     // Run the monomorphization collector and partition the collected items into
     // codegen units.
-    let codegen_units = tcx.collect_and_partition_mono_items(LOCAL_CRATE).1;
+    let (def_ids, codegen_units) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
     let codegen_units = (*codegen_units).clone();
 
     // Force all codegen_unit queries so they are already either red or green
@@ -950,7 +949,7 @@ pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     ongoing_codegen.check_for_errors(tcx.sess);
 
     assert_and_save_dep_graph(tcx);
-    ongoing_codegen
+    (ongoing_codegen, def_ids)
 }
 
 fn assert_and_save_dep_graph<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -73,7 +73,9 @@ pub use llvm_util::target_features;
 use std::any::Any;
 use std::path::{PathBuf};
 use std::sync::mpsc;
+use std::sync::Arc;
 use rustc_data_structures::sync::Lrc;
+use rustc::util::nodemap::DefIdSet;
 
 use rustc::dep_graph::DepGraph;
 use rustc::hir::def_id::CrateNum;
@@ -210,8 +212,9 @@ impl CodegenBackend for LlvmCodegenBackend {
         &self,
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
         rx: mpsc::Receiver<Box<dyn Any + Send>>
-    ) -> Box<dyn Any> {
-        box base::codegen_crate(tcx, rx)
+    ) -> (Box<dyn Any>, Arc<DefIdSet>) {
+        let cgr = base::codegen_crate(tcx, rx);
+        (box cgr.0, cgr.1)
     }
 
     fn join_codegen_and_link(

--- a/src/librustc_codegen_utils/codegen_backend.rs
+++ b/src/librustc_codegen_utils/codegen_backend.rs
@@ -43,6 +43,7 @@ use rustc::middle::cstore::MetadataLoader;
 use rustc::dep_graph::DepGraph;
 use rustc_target::spec::Target;
 use rustc_data_structures::fx::FxHashMap;
+use rustc::util::nodemap::DefIdSet;
 use rustc_mir::monomorphize::collector;
 use link::out_filename;
 
@@ -63,7 +64,7 @@ pub trait CodegenBackend {
         &self,
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
         rx: mpsc::Receiver<Box<dyn Any + Send>>
-    ) -> Box<dyn Any>;
+    ) -> (Box<dyn Any>, Arc<DefIdSet>);
 
     /// This is called on the returned `Box<dyn Any>` from `codegen_backend`
     ///
@@ -145,19 +146,18 @@ impl CodegenBackend for MetadataOnlyCodegenBackend {
         &self,
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
         _rx: mpsc::Receiver<Box<dyn Any + Send>>
-    ) -> Box<dyn Any> {
+    ) -> (Box<dyn Any>, Arc<DefIdSet>) {
         use rustc_mir::monomorphize::item::MonoItem;
 
         ::check_for_rustc_errors_attr(tcx);
         ::symbol_names_test::report_symbol_names(tcx);
         ::rustc_incremental::assert_dep_graph(tcx);
         ::rustc_incremental::assert_module_sources::assert_module_sources(tcx);
-        ::rustc_mir::monomorphize::assert_symbols_are_distinct(tcx,
-            collector::collect_crate_mono_items(
-                tcx,
-                collector::MonoItemCollectionMode::Eager
-            ).0.iter()
-        );
+
+        let (monos, _inline_map) = collector::collect_crate_mono_items(
+            tcx, collector::MonoItemCollectionMode::Eager);
+        ::rustc_mir::monomorphize::assert_symbols_are_distinct(tcx, monos.iter());
+
         // FIXME: Fix this
         // ::rustc::middle::dependency_format::calculate(tcx);
         let _ = tcx.link_args(LOCAL_CRATE);
@@ -182,11 +182,19 @@ impl CodegenBackend for MetadataOnlyCodegenBackend {
 
         let metadata = tcx.encode_metadata();
 
-        box OngoingCodegen {
+        let def_ids: DefIdSet = monos.iter().filter_map(|mono_item| {
+            match *mono_item {
+                MonoItem::Fn(ref instance) => Some(instance.def_id()),
+                MonoItem::Static(def_id) => Some(def_id),
+                _ => None,
+            }
+        }).collect();
+
+        (box OngoingCodegen {
             metadata: metadata,
             metadata_version: tcx.metadata_encoding_version().to_vec(),
             crate_name: tcx.crate_name(LOCAL_CRATE),
-        }
+        }, Arc::new(def_ids))
     }
 
     fn join_codegen_and_link(

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -33,6 +33,8 @@ rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_traits = { path = "../librustc_traits" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_typeck = { path = "../librustc_typeck" }
+rustc_yk_sections = { path = "../librustc_yk_sections" }
+rustc_yk_link = { path = "../librustc_yk_link" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 smallvec = { version = "0.6.5", features = ["union"] }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -63,6 +63,8 @@ extern crate log;
 extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;
+extern crate rustc_yk_sections;
+extern crate rustc_yk_link;
 
 use driver::CompileController;
 use pretty::{PpMode, UserIdentifiedItem};

--- a/src/librustc_yk_link/Cargo.toml
+++ b/src/librustc_yk_link/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Edd Barrett <vext01@gmail.com>"]
+name = "rustc_yk_link"
+version = "0.0.0"
+
+[lib]
+name = "rustc_yk_link"
+path = "lib.rs"
+test = false
+crate-type = ["dylib"]
+
+[dependencies]

--- a/src/librustc_yk_link/lib.rs
+++ b/src/librustc_yk_link/lib.rs
@@ -1,0 +1,58 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fs;
+use std::path::{PathBuf, Path};
+use std::process::Command;
+
+/// An extra ELF object file to link into the resulting binary.
+pub struct YkExtraLinkObject(PathBuf);
+
+#[cfg(target_arch = "x86_64")]
+const BFD_NAME: &'static str = "elf64-x86-64";
+
+#[cfg(target_arch = "x86_64")]
+const BFD_ARCH: &'static str = "i386";
+
+impl YkExtraLinkObject {
+    /// Creates an ELF object file using the raw binary data stored in the file at `source_path`.
+    /// The data will be put into a section named `sec_name`. The resulting object file is deleted
+    /// when it falls out of scope.
+    pub fn new(source_path: &Path, section_name: &str) -> Self {
+        let out_filename = format!("{}.o", source_path.to_str().unwrap());
+
+        let sec_arg = format!(".data={},alloc,load,readonly,data,contents", section_name);
+        let mut cmd = Command::new("objcopy");
+        cmd.args(&[
+            "-I", "binary",
+            "-O", BFD_NAME,
+            "-B", BFD_ARCH,
+            "--rename-section", &sec_arg,
+            "-j", ".data",
+            source_path.to_str().unwrap(), &out_filename]);
+
+        let output = cmd.output().unwrap();
+        if !output.status.success() {
+            eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            panic!("objcopy failed");
+        }
+        YkExtraLinkObject(PathBuf::from(out_filename))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0.as_path()
+    }
+}
+
+impl Drop for YkExtraLinkObject {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Edd Barrett <vext01@gmail.com>"]
+name = "rustc_yk_sections"
+version = "0.0.0"
+
+[lib]
+name = "rustc_yk_sections"
+path = "lib.rs"
+crate-type = ["dylib"]
+test = false
+
+[dependencies]
+rustc = {path = "../librustc"}
+rustc_yk_link = { path = "../librustc_yk_link" }
+mkstemp-rs = "1.0"
+byteorder = "1.2"

--- a/src/librustc_yk_sections/lib.rs
+++ b/src/librustc_yk_sections/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(box_patterns)]
+
+extern crate rustc;
+extern crate rustc_yk_link;
+extern crate byteorder;
+extern crate mkstemp;
+
+pub mod mir_cfg;

--- a/src/librustc_yk_sections/mir_cfg.rs
+++ b/src/librustc_yk_sections/mir_cfg.rs
@@ -1,0 +1,204 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Custom CFG serialiser for Yorick.
+/// At the time of writing no crate using `proc_macro` can be used in-compiler, otherwise we'd have
+/// used Serde.
+
+use rustc::ty::TyCtxt;
+
+use rustc::hir::def_id::DefId;
+use rustc::mir::{Mir, TerminatorKind, Operand, Constant, BasicBlock};
+use rustc::ty::{TyS, TyKind, Const};
+use rustc::util::nodemap::DefIdSet;
+use std::path::PathBuf;
+use mkstemp::TempFile;
+use rustc_yk_link::YkExtraLinkObject;
+use std::fs;
+use byteorder::{NativeEndian, WriteBytesExt};
+
+// Edge kinds.
+const GOTO: u8 = 0;
+const SWITCHINT: u8 = 1;
+const RESUME: u8 = 2;
+const ABORT: u8 = 3;
+const RETURN: u8 = 4;
+const UNREACHABLE: u8 = 5;
+const DROP_NO_UNWIND: u8 = 6;
+const DROP_WITH_UNWIND: u8 = 7;
+const DROP_AND_REPLACE_NO_UNWIND: u8 = 8;
+const DROP_AND_REPLACE_WITH_UNWIND: u8 = 9;
+const CALL_NO_CLEANUP: u8 = 10;
+const CALL_WITH_CLEANUP: u8 = 11;
+const CALL_UNKNOWN_NO_CLEANUP: u8 = 12;
+const CALL_UNKNOWN_WITH_CLEANUP: u8 = 13;
+const ASSERT_NO_CLEANUP: u8 = 14;
+const ASSERT_WITH_CLEANUP: u8 = 15;
+const YIELD_NO_DROP: u8 = 16;
+const YIELD_WITH_DROP: u8 = 17;
+const GENERATOR_DROP: u8 = 18;
+const FALSE_EDGES: u8 = 19;
+const FALSE_UNWIND: u8 = 20;
+const NO_MIR: u8 = 254;
+const SENTINAL: u8 = 255;
+
+const MIR_CFG_SECTION_NAME: &'static str = ".yk_mir_cfg";
+const MIR_CFG_TEMPLATE: &'static str = ".ykcfg.XXXXXXXX";
+const SECTION_VERSION: u16 = 0;
+
+/// Serialises the control flow for the given `DefId`s into a ELF object file and returns a handle for linking.
+pub fn emit_mir_cfg_section<'a, 'tcx, 'gcx>(tcx: &'a TyCtxt<'a, 'tcx, 'gcx>, def_ids: &DefIdSet) -> YkExtraLinkObject {
+    // First serialise the CFG into a plain binary file.
+    let mut template = std::env::temp_dir();
+    template.push(MIR_CFG_TEMPLATE);
+    let mut fh = TempFile::new(template.to_str().unwrap(), false).unwrap();
+
+    // Write a version field for sanity checking when deserialising.
+    fh.write_u16::<NativeEndian>(SECTION_VERSION).unwrap();
+
+    for def_id in def_ids {
+        if tcx.is_mir_available(*def_id) {
+            process_mir(&mut fh, tcx, def_id, tcx.optimized_mir(*def_id));
+        } else {
+            fh.write_u8(NO_MIR).unwrap();
+            fh.write_u64::<NativeEndian>(tcx.crate_hash(def_id.krate).as_u64()).unwrap();
+            fh.write_u32::<NativeEndian>(def_id.index.as_raw_u32()).unwrap();
+        }
+    }
+
+    // Write end-of-section sentinal.
+    fh.write_u8(SENTINAL).unwrap();
+
+    // Now graft it into an object file.
+    let path = PathBuf::from(fh.path());
+    let ret = YkExtraLinkObject::new(&path, MIR_CFG_SECTION_NAME);
+    fs::remove_file(path).unwrap();
+
+    ret
+}
+
+/// For each block in the given MIR write out one CFG edge record.
+fn process_mir(fh: &mut TempFile, tcx: &TyCtxt, def_id: &DefId, mir: &Mir) {
+    for (bb, maybe_bb_data) in mir.basic_blocks().iter_enumerated() {
+        let bb_data = maybe_bb_data.terminator.as_ref().unwrap();
+        match bb_data.kind {
+            TerminatorKind::Goto{target: target_bb} => {
+                write_rec_header(fh, tcx, GOTO, def_id, bb);
+                fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+            },
+            TerminatorKind::SwitchInt{ref targets, ..} => {
+                write_rec_header(fh, tcx, SWITCHINT, def_id, bb);
+
+                if cfg!(target_pointer_width = "64") {
+                    fh.write_u64::<NativeEndian>(targets.len() as u64).unwrap();
+                } else {
+                    panic!("unknown pointer width");
+                }
+
+                for target_bb in targets {
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Resume => write_rec_header(fh, tcx, RESUME, def_id, bb),
+            TerminatorKind::Abort => write_rec_header(fh, tcx, ABORT, def_id, bb),
+            TerminatorKind::Return => write_rec_header(fh, tcx, RETURN, def_id, bb),
+            TerminatorKind::Unreachable => write_rec_header(fh, tcx, UNREACHABLE, def_id, bb),
+            TerminatorKind::Drop{target: target_bb, unwind: opt_unwind_bb, ..} => {
+                if let Some(unwind_bb) = opt_unwind_bb {
+                    write_rec_header(fh, tcx, DROP_WITH_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(unwind_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, DROP_NO_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::DropAndReplace{target: target_bb, unwind: opt_unwind_bb, ..} => {
+                if let Some(unwind_bb) = opt_unwind_bb {
+                    write_rec_header(fh, tcx, DROP_AND_REPLACE_WITH_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(unwind_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, DROP_AND_REPLACE_NO_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Call{ref func, cleanup: opt_cleanup_bb, ..} => {
+                if let Operand::Constant(box Constant {
+                    literal: Const {
+                        ty: &TyS {
+                            sty: TyKind::FnDef(target_def_id, _substs), ..
+                        }, ..
+                    }, ..
+                }, ..) = func {
+                    // A statically known call target.
+                    if opt_cleanup_bb.is_some() {
+                        write_rec_header(fh, tcx, CALL_WITH_CLEANUP, def_id, bb);
+                    } else {
+                        write_rec_header(fh, tcx, CALL_NO_CLEANUP, def_id, bb);
+                    }
+
+                    fh.write_u64::<NativeEndian>(tcx.crate_hash(target_def_id.krate).as_u64()).unwrap();
+                    fh.write_u32::<NativeEndian>(target_def_id.index.as_raw_u32()).unwrap();
+
+                    if let Some(cleanup_bb) = opt_cleanup_bb {
+                        fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                    }
+                } else {
+                    // It's a kind of call that we can't statically know the target of.
+                    if let Some(cleanup_bb) = opt_cleanup_bb {
+                        write_rec_header(fh, tcx, CALL_UNKNOWN_WITH_CLEANUP, def_id, bb);
+                        fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                    } else {
+                        write_rec_header(fh, tcx, CALL_UNKNOWN_NO_CLEANUP, def_id, bb);
+                    }
+                }
+            },
+            TerminatorKind::Assert{target: target_bb, cleanup: opt_cleanup_bb, ..} => {
+                if let Some(cleanup_bb) = opt_cleanup_bb {
+                    write_rec_header(fh, tcx, ASSERT_WITH_CLEANUP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, ASSERT_NO_CLEANUP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Yield{resume: resume_bb, drop: opt_drop_bb, ..} => {
+                if let Some(drop_bb) = opt_drop_bb {
+                    write_rec_header(fh, tcx, YIELD_WITH_DROP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(resume_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(drop_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, YIELD_NO_DROP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(resume_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::GeneratorDrop => write_rec_header(fh, tcx, GENERATOR_DROP, def_id, bb),
+            TerminatorKind::FalseEdges{real_target: real_target_bb, ..} => {
+                // Fake edges not considered.
+                write_rec_header(fh, tcx, FALSE_EDGES, def_id, bb);
+                fh.write_u32::<NativeEndian>(real_target_bb.index() as u32).unwrap();
+            },
+            TerminatorKind::FalseUnwind{real_target: real_target_bb, ..} => {
+                // Fake edges not considered.
+                write_rec_header(fh, tcx, FALSE_UNWIND, def_id, bb);
+                fh.write_u32::<NativeEndian>(real_target_bb.index() as u32).unwrap();
+            },
+        }
+    }
+}
+
+/// Writes the "header" of a record, which is common to all record types.
+fn write_rec_header(fh: &mut TempFile, tcx: &TyCtxt, kind: u8, def_id: &DefId, bb: BasicBlock) {
+    fh.write_u8(kind).unwrap();
+    fh.write_u64::<NativeEndian>(tcx.crate_hash(def_id.krate).as_u64()).unwrap();
+    fh.write_u32::<NativeEndian>(def_id.index.as_raw_u32()).unwrap();
+    fh.write_u32::<NativeEndian>(bb.index() as u32).unwrap();
+}


### PR DESCRIPTION
This is used to verify that a PT trace -- once mapped back to MIR
locations -- makes sense. I imagine that we will also need a superset of this information later for trace optimisation, but that's just a hunch.

The sub-crate `rustc_yk_link` is separate to avoid a circular dependency.