### PR TITLE
The First *Real* Bors PR.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Build script for continuous integration.
+
+./x.py clean  # We don't clone afresh to save time and bandwidth.
+
+# XXX Enable compiler tests once we have addressed:
+# https://github.com/softdevteam/ykrustc/issues/10
+RUST_BACKTRACE=1 ./x.py build --stage 1 src/libtest

--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -1,0 +1,10 @@
+# Config file for continuous integration.
+
+[rust]
+# Use threads.
+codegen-units = 0
+
+[target.x86_64-unknown-linux-gnu]
+# Hsiangkai's LLVM at 4d9f26638007efe1c0dd8ccd689bad808df5a772
+# See README_YORICK.md for more on this.
+llvm-config = "/opt/llvm-hsiangkai/bin/llvm-config"

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+# The service providing the commit statuses to GitHub.
+status = [
+  "buildbot/buildbot-build-script"
+]
+
+# Allow two hours for builds.
+timeout_sec = 7200
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true

--- a/src/librustc_yk_sections/mir_cfg.rs
+++ b/src/librustc_yk_sections/mir_cfg.rs
@@ -52,8 +52,10 @@ const MIR_CFG_SECTION_NAME: &'static str = ".yk_mir_cfg";
 const MIR_CFG_TEMPLATE: &'static str = ".ykcfg.XXXXXXXX";
 const SECTION_VERSION: u16 = 0;
 
-/// Serialises the control flow for the given `DefId`s into a ELF object file and returns a handle for linking.
-pub fn emit_mir_cfg_section<'a, 'tcx, 'gcx>(tcx: &'a TyCtxt<'a, 'tcx, 'gcx>, def_ids: &DefIdSet) -> YkExtraLinkObject {
+/// Serialises the control flow for the given `DefId`s into a ELF object file and returns a handle
+/// for linking.
+pub fn emit_mir_cfg_section<'a, 'tcx, 'gcx>(tcx: &'a TyCtxt<'a, 'tcx, 'gcx>,
+                                            def_ids: &DefIdSet) -> YkExtraLinkObject {
     // First serialise the CFG into a plain binary file.
     let mut template = std::env::temp_dir();
     template.push(MIR_CFG_TEMPLATE);
@@ -144,7 +146,8 @@ fn process_mir(fh: &mut TempFile, tcx: &TyCtxt, def_id: &DefId, mir: &Mir) {
                         write_rec_header(fh, tcx, CALL_NO_CLEANUP, def_id, bb);
                     }
 
-                    fh.write_u64::<NativeEndian>(tcx.crate_hash(target_def_id.krate).as_u64()).unwrap();
+                    fh.write_u64::<NativeEndian>(tcx.crate_hash(
+                        target_def_id.krate).as_u64()).unwrap();
                     fh.write_u32::<NativeEndian>(target_def_id.index.as_raw_u32()).unwrap();
 
                     if let Some(cleanup_bb) = opt_cleanup_bb {


### PR DESCRIPTION
This change enables buildbot and bors-ng on this repo.

The `.buildbot.sh` script is called to run the build when bors is told to try or rollup.

The name of the script is under our control, so we can rename it if we want.

Please ask questions if you have any!