### PR TITLE
Use our .buildbot.toml for our x.py config.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -6,4 +6,4 @@
 
 # XXX Enable compiler tests once we have addressed:
 # https://github.com/softdevteam/ykrustc/issues/10
-RUST_BACKTRACE=1 ./x.py build --stage 1 src/libtest
+RUST_BACKTRACE=1 ./x.py build --config .buildbot.toml --stage 1 src/libtest


### PR DESCRIPTION
The last build didn't use our `x.py` config file, so amongst other things, it compiled a stock LLVM afresh. That's not what we want.

(my bad, sorry, but at least we get some more bors practice :) )