### PR TITLE
Don't assume a function has debug info just because the LLVM debug context is present.

### DIFF
--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -314,10 +314,6 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
             local_gen_sym_counter: Cell::new(0),
         }
     }
-
-    pub fn has_debug(&self) -> bool {
-        self.dbg_cx.is_some()
-    }
 }
 
 impl<'b, 'tcx> CodegenCx<'b, 'tcx> {

--- a/src/librustc_codegen_llvm/mir/block.rs
+++ b/src/librustc_codegen_llvm/mir/block.rs
@@ -52,7 +52,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
 
         // Insert a DWARF label at the start of each block.
         // Yorick uses this at runtime to map virtual addresses to MIR blocks.
-        if self.cx.has_debug()  {
+        if self.has_debug() {
             let di_bldr = DIB(self.cx);
 
             // Make a name for the label that uniquely identifies where in the MIR we are.

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -126,6 +126,13 @@ impl FunctionCx<'a, 'll, 'tcx> {
         debuginfo::set_source_location(&self.debug_context, bx, scope, span);
     }
 
+    pub fn has_debug(&self) -> bool {
+        match self.debug_context {
+            FunctionDebugContext::RegularContext(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn debug_loc(&mut self, source_info: mir::SourceInfo) -> (Option<&'ll DIScope>, Span) {
         // Bail out if debug info emission is not enabled.
         match self.debug_context {


### PR DESCRIPTION
For example, the function may be annotated `#[no_debug]`.

The `has_debug` function being removed was one I added in an earlier
Yorick-related commit (it's not upstream code being removed):
b6966b9deec6da8fdfe0bb6748a24b67de342351

This does not fix my LLVM woes, but it's a change we will need to fix a compiler crash when building `ykrt`.