### PR TITLE
Gate-off existing hardware tracer label support.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,6 +4,11 @@
 
 ./x.py clean  # We don't clone afresh to save time and bandwidth.
 
-# XXX Enable compiler tests once we have addressed:
-# https://github.com/softdevteam/ykrustc/issues/10
-RUST_BACKTRACE=1 ./x.py build --config .buildbot.toml --stage 1 src/libtest
+# Note that the gdb must be Python enabled.
+#
+# We are running a subset of tests for now since the gdb compile tests are
+# currently failing due to out of data upstream code:
+# https://github.com/softdevteam/ykrustc/pull/14#issuecomment-440608570
+PATH=/opt/gdb-8.2/bin:${PATH} RUST_BACKTRACE=1 \
+    ./x.py test --config .buildbot.toml \
+    src/test/ui src/test/compile-fail src/test/run-pass

--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -3,8 +3,3 @@
 [rust]
 # Use threads.
 codegen-units = 0
-
-[target.x86_64-unknown-linux-gnu]
-# Hsiangkai's LLVM at 4d9f26638007efe1c0dd8ccd689bad808df5a772
-# See README_YORICK.md for more on this.
-llvm-config = "/opt/llvm-hsiangkai/bin/llvm-config"

--- a/README_YORICK.md
+++ b/README_YORICK.md
@@ -1,24 +1,4 @@
 # Yorick-specific Notes
 
-## LLVM Version
-
-ykrustc requires a version of LLVM supporting code-gen for DILabels.
-
-At the time of writing, this has not been merged into master. More details can
-be found here:
-https://reviews.llvm.org/D45045
-
-Until this is merged, use the `master` branch in:
-https://github.com/Hsiangkai/llvm.git
-
-ykrustc was developed using version 4d9f26638007efe1c0dd8ccd689bad808df5a772.
-
-Don't forget to update `llvm-config` in your config.toml:
-
-```
-[llvm]
-...
-llvm-config = "/path/to/your/llvm/install/bin/llvm-config"
-```
-
-If you don't have a `config.toml`, you can use `config.toml.example` as a base.
+Experimental code for hardware tracing is gated by `#[cfg(yk_hwt)]`. Software
+tracing support will still be available if this compile-time variable is unset.

--- a/bors.toml
+++ b/bors.toml
@@ -3,8 +3,8 @@ status = [
   "buildbot/buildbot-build-script"
 ]
 
-# Allow two hours for builds.
-timeout_sec = 7200
+# Allow eight hours for builds + tests.
+timeout_sec = 28800
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -11,7 +11,9 @@
 use common::{C_i32, C_null};
 use libc::c_uint;
 use llvm::{self, BasicBlock};
-use llvm::debuginfo::{DIScope, DISubprogram};
+use llvm::debuginfo::DIScope;
+#[cfg(yk_hwt)]
+use llvm::DISubprogram;
 use rustc::ty::{self, Ty, TypeFoldable, UpvarSubsts};
 use rustc::ty::layout::{LayoutOf, TyLayout};
 use rustc::mir::{self, Mir};
@@ -117,6 +119,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
         )
     }
 
+    #[cfg(yk_hwt)]
     pub fn fn_metadata(&self, span: Span) -> &DISubprogram {
         self.debug_context.get_ref(span).fn_metadata
     }
@@ -126,6 +129,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
         debuginfo::set_source_location(&self.debug_context, bx, scope, span);
     }
 
+    #[cfg(yk_hwt)]
     pub fn has_debug(&self) -> bool {
         match self.debug_context {
             FunctionDebugContext::RegularContext(_) => true,


### PR DESCRIPTION
We are going to move our focus to a software tracer until either LLVM
DILabel support matures, or until our own codegen is completed.
We do this by adding a `yk_hwt` compile-time gate, which is off by
default.

I've left our (harmless) changes to the backend traits as they would be
awkward to gate (signature change would require a copy of the
functions).

Since we won't be using DILabels just yet, we no longer need a bleeding edge LLVM (and actually Rust synced a newer LLVM recently anyway).

While we are here, enable compiler tests and bump the bors timeout.

(Timeout also bumped on the buildbot master).