### PR TITLE
Import old work minus compile-time disabled hardware tracer code.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Build script for continuous integration.
+
+./x.py clean  # We don't clone afresh to save time and bandwidth.
+git clean -dffx # If upstream removes a submodule, remove the files from disk.
+
+# Note that the gdb must be Python enabled.
+PATH=/opt/gdb-8.2/bin:${PATH} RUST_BACKTRACE=1 YK_DEBUG_SECTIONS=1 \
+    ./x.py test --config .buildbot.toml

--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -1,0 +1,5 @@
+# Config file for continuous integration.
+
+[rust]
+# Use threads.
+codegen-units = 0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # The Rust Programming Language
 
-This is the main source code repository for [Rust]. It contains the compiler,
-standard library, and documentation.
+This is a modified version of the Rust compiler for the Yorick meta-tracer.
 
-[Rust]: https://www.rust-lang.org
+For Yorick-specific notes, see `README_YORICK.md`.
 
 ## Quick Start
 [quick-start]: #quick-start

--- a/README_YORICK.md
+++ b/README_YORICK.md
@@ -1,0 +1,4 @@
+# Yorick-specific Notes
+
+To enable the experimental `.yk_mir_cfg` ELF section, set `YK_DEBUG_SECTIONS`
+in your environment.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+# The service providing the commit statuses to GitHub.
+status = [
+  "buildbot/buildbot-build-script"
+]
+
+# Allow eight hours for builds + tests.
+timeout_sec = 28800
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "rustc_errors 0.0.0",
  "rustc_fs_util 0.0.0",
  "rustc_target 0.0.0",
+ "rustc_yk_link 0.0.0",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2162,6 +2163,7 @@ dependencies = [
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_codegen_ssa 0.0.0",
  "rustc_llvm 0.0.0",
+ "rustc_yk_sections 0.0.0",
 ]
 
 [[package]]
@@ -2245,6 +2247,8 @@ dependencies = [
  "rustc_target 0.0.0",
  "rustc_traits 0.0.0",
  "rustc_typeck 0.0.0",
+ "rustc_yk_link 0.0.0",
+ "rustc_yk_sections 0.0.0",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2506,6 +2510,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc_yk_link"
+version = "0.0.0"
+
+[[package]]
+name = "rustc_yk_sections"
+version = "0.0.0"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc 0.0.0",
+ "rustc_codegen_utils 0.0.0",
+ "rustc_yk_link 0.0.0",
 ]
 
 [[package]]

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -25,6 +25,7 @@ rustc_apfloat = { path = "../librustc_apfloat" }
 rustc_target = { path = "../librustc_target" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
+rustc_yk_link = { path = "../librustc_yk_link" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -93,6 +93,7 @@ extern crate parking_lot;
 extern crate rustc_errors as errors;
 extern crate rustc_rayon as rayon;
 extern crate rustc_rayon_core as rayon_core;
+extern crate rustc_yk_link;
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
 extern crate syntax_pos;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -24,6 +24,7 @@ use session::config::{OutputType, Lto};
 use util::nodemap::{FxHashMap, FxHashSet};
 use util::common::{duration_to_secs_str, ErrorReported};
 use util::common::ProfileQueriesMsg;
+use rustc_yk_link::YkExtraLinkObject;
 
 use rustc_data_structures::base_n;
 use rustc_data_structures::sync::{self, Lrc, Lock, LockCell, OneThread, Once, RwLock};
@@ -61,6 +62,9 @@ pub mod search_paths;
 /// Represents the data associated with a compilation
 /// session for a single crate.
 pub struct Session {
+    /// A list of additional objects to link in for Yorick support.
+    pub yk_link_objects: RefCell<Vec<YkExtraLinkObject>>,
+
     pub target: config::Config,
     pub host: Target,
     pub opts: config::Options,
@@ -1137,6 +1141,7 @@ pub fn build_session_(
     };
 
     let sess = Session {
+        yk_link_objects: RefCell::new(Vec::new()),
         target: target_cfg,
         host,
         opts: sopts,

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -15,6 +15,7 @@ num_cpus = "1.0"
 rustc-demangle = "0.1.4"
 rustc_codegen_ssa = { path = "../librustc_codegen_ssa" }
 rustc_llvm = { path = "../librustc_llvm" }
+rustc_yk_sections = { path = "../librustc_yk_sections" }
 memmap = "0.6"
 
 [features]

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -14,7 +14,8 @@ mod doc;
 use rustc_codegen_ssa::debuginfo::VariableAccess::*;
 use rustc_codegen_ssa::debuginfo::VariableKind::*;
 
-use self::utils::{DIB, span_start, create_DIArray, is_node_local_to_unit};
+use self::utils::{create_DIArray, is_node_local_to_unit};
+pub (crate) use self::utils::{DIB, span_start};
 use self::namespace::mangled_name_of_instance;
 use self::type_names::compute_debuginfo_type_name;
 use self::metadata::{type_metadata, file_metadata, TypeMap};

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -33,6 +33,8 @@ rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_traits = { path = "../librustc_traits" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_typeck = { path = "../librustc_typeck" }
+rustc_yk_sections = { path = "../librustc_yk_sections" }
+rustc_yk_link = { path = "../librustc_yk_link" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 smallvec = { version = "0.6.5", features = ["union"] }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -11,6 +11,7 @@
 use rustc::dep_graph::DepGraph;
 use rustc::hir::{self, map as hir_map};
 use rustc::hir::lowering::lower_crate;
+use rustc::hir::def_id::LOCAL_CRATE;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_mir as mir;
@@ -33,11 +34,15 @@ use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::{self, CStore};
 use rustc_traits;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
+use rustc_codegen_utils::link::out_filename;
 use rustc_typeck as typeck;
 use rustc_privacy;
 use rustc_plugin::registry::Registry;
 use rustc_plugin as plugin;
 use rustc_passes::{self, ast_validation, hir_stats, loops, rvalue_promotion};
+use rustc_yk_sections::mir_cfg::emit_mir_cfg_section;
+use rustc_yk_sections::with_yk_debug_sections;
+use rustc::util::nodemap::DefIdSet;
 use super::Compilation;
 
 use serialize::json;
@@ -50,7 +55,7 @@ use std::io::{self, Write};
 use std::iter;
 use std::path::{Path, PathBuf};
 use rustc_data_structures::sync::{self, Lrc, Lock};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use syntax::{self, ast, attr, diagnostics, visit};
 use syntax::early_buffered_lints::BufferedEarlyLint;
 use syntax::ext::base::ExtCtxt;
@@ -325,7 +330,7 @@ pub fn compile_input(
                     tcx.print_debug_stats();
                 }
 
-                let ongoing_codegen = phase_4_codegen(&*codegen_backend, tcx, rx);
+                let (ongoing_codegen, def_ids) = phase_4_codegen(&*codegen_backend, tcx, rx);
 
                 if log_enabled!(::log::Level::Info) {
                     println!("Post-codegen");
@@ -337,6 +342,17 @@ pub fn compile_input(
                         sess.err(&format!("could not emit MIR: {}", e));
                         sess.abort_if_errors();
                     }
+                }
+
+                // Output Yorick debug sections into binary targets.
+                if sess.crate_types.borrow().contains(&config::CrateType::Executable) &&
+                    with_yk_debug_sections() {
+                    let out_fname = out_filename(
+                        tcx.sess, config::CrateType::Executable, &outputs,
+                        &*tcx.crate_name(LOCAL_CRATE).as_str());
+
+                    tcx.sess.yk_link_objects.borrow_mut()
+                       .push(emit_mir_cfg_section(&tcx, &def_ids, out_fname));
                 }
 
                 Ok((outputs.clone(), ongoing_codegen, tcx.dep_graph.clone()))
@@ -1363,19 +1379,20 @@ pub fn phase_4_codegen<'a, 'tcx>(
     codegen_backend: &dyn CodegenBackend,
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     rx: mpsc::Receiver<Box<dyn Any + Send>>,
-) -> Box<dyn Any> {
+) -> (Box<dyn Any>, Arc<DefIdSet>) {
     time(tcx.sess, "resolving dependency formats", || {
         ::rustc::middle::dependency_format::calculate(tcx)
     });
 
     tcx.sess.profiler(|p| p.start_activity(ProfileCategory::Codegen));
-    let codegen = time(tcx.sess, "codegen", move || codegen_backend.codegen_crate(tcx, rx));
+    let (codegen, def_ids) =
+        time(tcx.sess, "codegen", move || codegen_backend.codegen_crate(tcx, rx));
     tcx.sess.profiler(|p| p.end_activity(ProfileCategory::Codegen));
     if tcx.sess.profile_queries() {
         profile::dump(&tcx.sess, "profile_queries".to_string())
     }
 
-    codegen
+    (codegen, def_ids)
 }
 
 fn escape_dep_filename(filename: &FileName) -> String {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -63,6 +63,8 @@ extern crate log;
 extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;
+extern crate rustc_yk_sections;
+extern crate rustc_yk_link;
 
 // Note that the linkage here should be all that we need, on Linux we're not
 // prefixing the symbols here so this should naturally override our default

--- a/src/librustc_yk_link/Cargo.toml
+++ b/src/librustc_yk_link/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+authors = ["Edd Barrett <vext01@gmail.com>"]
+name = "rustc_yk_link"
+version = "0.0.0"
+
+[lib]
+name = "rustc_yk_link"
+path = "lib.rs"
+test = false
+crate-type = ["dylib"]

--- a/src/librustc_yk_link/lib.rs
+++ b/src/librustc_yk_link/lib.rs
@@ -1,0 +1,58 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fs;
+use std::path::{PathBuf, Path};
+use std::process::Command;
+
+/// An extra ELF object file to link into the resulting binary.
+pub struct YkExtraLinkObject(PathBuf);
+
+#[cfg(target_arch = "x86_64")]
+const BFD_NAME: &'static str = "elf64-x86-64";
+
+#[cfg(target_arch = "x86_64")]
+const BFD_ARCH: &'static str = "i386";
+
+impl YkExtraLinkObject {
+    /// Creates an ELF object file using the raw binary data stored in the file at `source_path`.
+    /// The data will be put into a section named `sec_name`. The resulting object file is deleted
+    /// when it falls out of scope.
+    pub fn new(source_path: &Path, section_name: &str) -> Self {
+        let out_filename = format!("{}.o", source_path.to_str().unwrap());
+
+        let sec_arg = format!(".data={},alloc,load,readonly,data,contents", section_name);
+        let mut cmd = Command::new("objcopy");
+        cmd.args(&[
+            "-I", "binary",
+            "-O", BFD_NAME,
+            "-B", BFD_ARCH,
+            "--rename-section", &sec_arg,
+            "-j", ".data",
+            source_path.to_str().unwrap(), &out_filename]);
+
+        let output = cmd.output().unwrap();
+        if !output.status.success() {
+            eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            panic!("objcopy failed");
+        }
+        YkExtraLinkObject(PathBuf::from(out_filename))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0.as_path()
+    }
+}
+
+impl Drop for YkExtraLinkObject {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Edd Barrett <vext01@gmail.com>"]
+name = "rustc_yk_sections"
+version = "0.0.0"
+
+[lib]
+name = "rustc_yk_sections"
+path = "lib.rs"
+crate-type = ["dylib"]
+test = false
+
+[dependencies]
+rustc = { path = "../librustc" }
+rustc_yk_link = { path = "../librustc_yk_link" }
+rustc_codegen_utils = { path = "../librustc_codegen_utils" }
+byteorder = "1.2"

--- a/src/librustc_yk_sections/lib.rs
+++ b/src/librustc_yk_sections/lib.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(box_patterns)]
+
+extern crate rustc;
+extern crate rustc_yk_link;
+extern crate rustc_codegen_utils;
+extern crate byteorder;
+
+use std::env;
+
+/// Are Yorick debug sections enabled?
+pub fn with_yk_debug_sections() -> bool {
+    match env::var("YK_DEBUG_SECTIONS") {
+        Ok(_) => true,
+        _ => false,
+    }
+}
+
+pub mod mir_cfg;

--- a/src/librustc_yk_sections/mir_cfg.rs
+++ b/src/librustc_yk_sections/mir_cfg.rs
@@ -1,0 +1,214 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Custom CFG serialiser for Yorick.
+/// At the time of writing no crate using `proc_macro` can be used in-compiler, otherwise we'd have
+/// used Serde.
+
+use rustc::ty::TyCtxt;
+
+use rustc::hir::def_id::DefId;
+use rustc::mir::{Mir, TerminatorKind, Operand, Constant, BasicBlock};
+use rustc::ty::{TyS, TyKind, Const};
+use rustc::util::nodemap::DefIdSet;
+use std::path::PathBuf;
+use std::fs::File;
+use rustc_yk_link::YkExtraLinkObject;
+use std::fs;
+use byteorder::{NativeEndian, WriteBytesExt};
+
+// Edge kinds.
+const GOTO: u8 = 0;
+const SWITCHINT: u8 = 1;
+const RESUME: u8 = 2;
+const ABORT: u8 = 3;
+const RETURN: u8 = 4;
+const UNREACHABLE: u8 = 5;
+const DROP_NO_UNWIND: u8 = 6;
+const DROP_WITH_UNWIND: u8 = 7;
+const DROP_AND_REPLACE_NO_UNWIND: u8 = 8;
+const DROP_AND_REPLACE_WITH_UNWIND: u8 = 9;
+const CALL_NO_CLEANUP: u8 = 10;
+const CALL_WITH_CLEANUP: u8 = 11;
+const CALL_UNKNOWN_NO_CLEANUP: u8 = 12;
+const CALL_UNKNOWN_WITH_CLEANUP: u8 = 13;
+const ASSERT_NO_CLEANUP: u8 = 14;
+const ASSERT_WITH_CLEANUP: u8 = 15;
+const YIELD_NO_DROP: u8 = 16;
+const YIELD_WITH_DROP: u8 = 17;
+const GENERATOR_DROP: u8 = 18;
+const FALSE_EDGES: u8 = 19;
+const FALSE_UNWIND: u8 = 20;
+const NO_MIR: u8 = 254;
+const SENTINAL: u8 = 255;
+
+const MIR_CFG_SECTION_NAME: &'static str = ".yk_mir_cfg";
+const SECTION_VERSION: u16 = 0;
+
+/// Serialises the control flow for the given `DefId`s into a ELF object file and returns a handle
+/// for linking.
+pub fn emit_mir_cfg_section<'a, 'tcx, 'gcx>(
+    tcx: &'a TyCtxt<'a, 'tcx, 'gcx>, def_ids: &DefIdSet, exe_filename: PathBuf)
+    -> YkExtraLinkObject {
+
+    // Serialise the MIR into a file whose name is derived from the output binary. The filename
+    // must be the same between builds of the same binary for the reproducible build tests to pass.
+    let mut mir_path: String = exe_filename.to_str().unwrap().to_owned();
+    mir_path.push_str(".ykcfg");
+    let mut fh = File::create(&mir_path).unwrap();
+
+    // Write a version field for sanity checking when deserialising.
+    fh.write_u16::<NativeEndian>(SECTION_VERSION).unwrap();
+
+    // To satisfy the reproducible build tests, the CFG must be written out in a deterministic
+    // order, thus we sort the `DefId`s first.
+    let mut sorted_def_ids: Vec<&DefId> = def_ids.iter().collect();
+    sorted_def_ids.sort();
+
+    for def_id in sorted_def_ids {
+        if tcx.is_mir_available(*def_id) {
+            process_mir(&mut fh, tcx, def_id, tcx.optimized_mir(*def_id));
+        } else {
+            fh.write_u8(NO_MIR).unwrap();
+            fh.write_u64::<NativeEndian>(tcx.crate_hash(def_id.krate).as_u64()).unwrap();
+            fh.write_u32::<NativeEndian>(def_id.index.as_raw_u32()).unwrap();
+        }
+    }
+
+    // Write end-of-section sentinal.
+    fh.write_u8(SENTINAL).unwrap();
+
+    // Now graft it into an object file.
+    let path = PathBuf::from(mir_path);
+    let ret = YkExtraLinkObject::new(&path, MIR_CFG_SECTION_NAME);
+    fs::remove_file(path).unwrap();
+
+    ret
+}
+
+/// For each block in the given MIR write out one CFG edge record.
+fn process_mir(fh: &mut File, tcx: &TyCtxt, def_id: &DefId, mir: &Mir) {
+    for (bb, maybe_bb_data) in mir.basic_blocks().iter_enumerated() {
+        let bb_data = maybe_bb_data.terminator.as_ref().unwrap();
+        match bb_data.kind {
+            TerminatorKind::Goto{target: target_bb} => {
+                write_rec_header(fh, tcx, GOTO, def_id, bb);
+                fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+            },
+            TerminatorKind::SwitchInt{ref targets, ..} => {
+                write_rec_header(fh, tcx, SWITCHINT, def_id, bb);
+
+                if cfg!(target_pointer_width = "64") {
+                    fh.write_u64::<NativeEndian>(targets.len() as u64).unwrap();
+                } else {
+                    panic!("unknown pointer width");
+                }
+
+                for target_bb in targets {
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Resume => write_rec_header(fh, tcx, RESUME, def_id, bb),
+            TerminatorKind::Abort => write_rec_header(fh, tcx, ABORT, def_id, bb),
+            TerminatorKind::Return => write_rec_header(fh, tcx, RETURN, def_id, bb),
+            TerminatorKind::Unreachable => write_rec_header(fh, tcx, UNREACHABLE, def_id, bb),
+            TerminatorKind::Drop{target: target_bb, unwind: opt_unwind_bb, ..} => {
+                if let Some(unwind_bb) = opt_unwind_bb {
+                    write_rec_header(fh, tcx, DROP_WITH_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(unwind_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, DROP_NO_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::DropAndReplace{target: target_bb, unwind: opt_unwind_bb, ..} => {
+                if let Some(unwind_bb) = opt_unwind_bb {
+                    write_rec_header(fh, tcx, DROP_AND_REPLACE_WITH_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(unwind_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, DROP_AND_REPLACE_NO_UNWIND, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Call{ref func, cleanup: opt_cleanup_bb, ..} => {
+                if let Operand::Constant(box Constant {
+                    literal: Const {
+                        ty: &TyS {
+                            sty: TyKind::FnDef(target_def_id, _substs), ..
+                        }, ..
+                    }, ..
+                }, ..) = func {
+                    // A statically known call target.
+                    if opt_cleanup_bb.is_some() {
+                        write_rec_header(fh, tcx, CALL_WITH_CLEANUP, def_id, bb);
+                    } else {
+                        write_rec_header(fh, tcx, CALL_NO_CLEANUP, def_id, bb);
+                    }
+
+                    fh.write_u64::<NativeEndian>(tcx.crate_hash(
+                        target_def_id.krate).as_u64()).unwrap();
+                    fh.write_u32::<NativeEndian>(target_def_id.index.as_raw_u32()).unwrap();
+
+                    if let Some(cleanup_bb) = opt_cleanup_bb {
+                        fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                    }
+                } else {
+                    // It's a kind of call that we can't statically know the target of.
+                    if let Some(cleanup_bb) = opt_cleanup_bb {
+                        write_rec_header(fh, tcx, CALL_UNKNOWN_WITH_CLEANUP, def_id, bb);
+                        fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                    } else {
+                        write_rec_header(fh, tcx, CALL_UNKNOWN_NO_CLEANUP, def_id, bb);
+                    }
+                }
+            },
+            TerminatorKind::Assert{target: target_bb, cleanup: opt_cleanup_bb, ..} => {
+                if let Some(cleanup_bb) = opt_cleanup_bb {
+                    write_rec_header(fh, tcx, ASSERT_WITH_CLEANUP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(cleanup_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, ASSERT_NO_CLEANUP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(target_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::Yield{resume: resume_bb, drop: opt_drop_bb, ..} => {
+                if let Some(drop_bb) = opt_drop_bb {
+                    write_rec_header(fh, tcx, YIELD_WITH_DROP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(resume_bb.index() as u32).unwrap();
+                    fh.write_u32::<NativeEndian>(drop_bb.index() as u32).unwrap();
+                } else {
+                    write_rec_header(fh, tcx, YIELD_NO_DROP, def_id, bb);
+                    fh.write_u32::<NativeEndian>(resume_bb.index() as u32).unwrap();
+                }
+            },
+            TerminatorKind::GeneratorDrop => write_rec_header(fh, tcx, GENERATOR_DROP, def_id, bb),
+            TerminatorKind::FalseEdges{real_target: real_target_bb, ..} => {
+                // Fake edges not considered.
+                write_rec_header(fh, tcx, FALSE_EDGES, def_id, bb);
+                fh.write_u32::<NativeEndian>(real_target_bb.index() as u32).unwrap();
+            },
+            TerminatorKind::FalseUnwind{real_target: real_target_bb, ..} => {
+                // Fake edges not considered.
+                write_rec_header(fh, tcx, FALSE_UNWIND, def_id, bb);
+                fh.write_u32::<NativeEndian>(real_target_bb.index() as u32).unwrap();
+            },
+        }
+    }
+}
+
+/// Writes the "header" of a record, which is common to all record types.
+fn write_rec_header(fh: &mut File, tcx: &TyCtxt, kind: u8, def_id: &DefId, bb: BasicBlock) {
+    fh.write_u8(kind).unwrap();
+    fh.write_u64::<NativeEndian>(tcx.crate_hash(def_id.krate).as_u64()).unwrap();
+    fh.write_u32::<NativeEndian>(def_id.index.as_raw_u32()).unwrap();
+    fh.write_u32::<NativeEndian>(bb.index() as u32).unwrap();
+}

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -15,7 +15,7 @@ extern crate rustc;
 extern crate rustc_codegen_utils;
 
 use std::any::Any;
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use syntax::symbol::Symbol;
 use rustc::session::{Session, CompileIncomplete};
 use rustc::session::config::OutputFilenames;
@@ -23,6 +23,7 @@ use rustc::ty::TyCtxt;
 use rustc::ty::query::Providers;
 use rustc::middle::cstore::MetadataLoader;
 use rustc::dep_graph::DepGraph;
+use rustc::util::nodemap::DefIdSet;
 use rustc_codegen_utils::codegen_backend::{CodegenBackend, MetadataOnlyCodegenBackend};
 
 struct TheBackend(Box<CodegenBackend>);
@@ -44,10 +45,10 @@ impl CodegenBackend for TheBackend {
         &self,
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
         _rx: mpsc::Receiver<Box<Any + Send>>
-    ) -> Box<Any> {
+    ) -> (Box<Any>, Arc<DefIdSet>) {
         use rustc::hir::def_id::LOCAL_CRATE;
 
-        Box::new(tcx.crate_name(LOCAL_CRATE) as Symbol)
+        (Box::new(tcx.crate_name(LOCAL_CRATE) as Symbol), Arc::new(DefIdSet::default()))
     }
 
     fn join_codegen_and_link(


### PR DESCRIPTION
This is going to be horrible to review as it's all one commit. Most of the incoming code here was reviewed in the old repo (now ykrustc.old). Sorry about this, but it's too hard to pick it all apart retrospectively.

As discussed the other day, we decided to start a fresh repo and copy over only what we want for now. All code that had been guarded with `yk_hwt` has been removed, and I've also fixed the tests along the way.

The tests all pass :)

Hopefully bors won't be upset that the repo has been pulled from under it's feet :)