### PR TITLE
The start of software tracing.

### DIFF
--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -1,5 +1,8 @@
 # Config file for continuous integration.
 
 [rust]
-# Use threads.
-codegen-units = 0
+codegen-units = 0           # Use many compilation units.
+debug-assertions = true     # Turn on assertions in rustc.
+
+[llvm]
+assertions = true           # Turn on assertions in LLVM.

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -229,6 +229,8 @@ mod nonzero;
 mod tuple;
 mod unit;
 
+mod yk_swt;
+
 // Pull in the `coresimd` crate directly into libcore. This is where all the
 // architecture-specific (and vendor-specific) intrinsics are defined. AKA
 // things like SIMD and such. Note that the actual source for all this lies in a

--- a/src/libcore/yk_swt.rs
+++ b/src/libcore/yk_swt.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// The software trace recorder function.
+/// This is a weak language item, it actually resides in libstd. It has to be weak to allow libcore
+/// to call up to libstd (libstd is not a dependency of libcore).
+extern "Rust" {
+    #[cfg_attr(not(stage0), lang="yk_swt_rec_loc")]
+    fn yk_swt_rec_loc(crate_hash: u64, def_idx: u32, bb: u32);
+}
+
+/// Wrapper lang item to call the above wrapper function.
+/// This has to be a lang item too, as a MIR terminator cannot call a weak language item directly.
+#[allow(dead_code)] // Used only indirectly in a MIR pass.
+#[cfg_attr(not(stage0), lang="yk_swt_rec_loc_wrap")]
+#[cfg_attr(not(stage0), no_trace)]
+fn yk_swt_rec_loc_wrap(crate_hash: u64, def_idx: u32, bb: u32) {
+    unsafe { yk_swt_rec_loc(crate_hash, def_idx, bb) };
+}
+

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -376,6 +376,9 @@ language_item_table! {
     I128ShroFnLangItem,          "i128_shro",          i128_shro_fn,            Target::Fn;
     U128ShroFnLangItem,          "u128_shro",          u128_shro_fn,            Target::Fn;
 
+    YkSwtRecLocLangItem,         "yk_swt_rec_loc",     yk_swt_rec_loc,          Target::Fn;
+    YkSwtRecLocWrapLangItem,     "yk_swt_rec_loc_wrap",yk_swt_rec_loc_wrap,     Target::Fn;
+
     // Align offset for stride != 1, must not panic.
     AlignOffsetLangItem,         "align_offset",       align_offset_fn,         Target::Fn;
 

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -168,4 +168,5 @@ weak_lang_items! {
     eh_personality,     EhPersonalityLangItem,      rust_eh_personality;
     eh_unwind_resume,   EhUnwindResumeLangItem,     rust_eh_unwind_resume;
     oom,                OomLangItem,                rust_oom;
+    yk_swt_rec_loc,     YkSwtRecLocLangItem,        rust_yk_swt_rec_loc;
 }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2036,6 +2036,16 @@ impl<'tcx> Const<'tcx> {
     }
 
     #[inline]
+    pub fn from_u32(tcx: TyCtxt<'_, '_, 'tcx>, n: u32) -> &'tcx Self {
+        Self::from_bits(tcx, n as u128, ParamEnv::empty().and(tcx.types.u32))
+    }
+
+    #[inline]
+    pub fn from_u64(tcx: TyCtxt<'_, '_, 'tcx>, n: u64) -> &'tcx Self {
+        Self::from_bits(tcx, n as u128, ParamEnv::empty().and(tcx.types.u64))
+    }
+
+    #[inline]
     pub fn to_bits(
         &self,
         tcx: TyCtxt<'_, '_, 'tcx>,

--- a/src/librustc_mir/transform/add_yk_swt_calls.rs
+++ b/src/librustc_mir/transform/add_yk_swt_calls.rs
@@ -1,0 +1,186 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc::ty::{self, TyCtxt, List};
+use rustc::mir::{Operand, LocalDecl, Place, SourceInfo, BasicBlock, Local, BasicBlockData,
+    TerminatorKind, Terminator, OUTERMOST_SOURCE_SCOPE, Constant, Mir};
+use rustc_data_structures::indexed_vec::Idx;
+use syntax_pos::DUMMY_SP;
+use syntax::attr;
+use transform::{MirPass, MirSource};
+use rustc::hir;
+use rustc::hir::def_id::{DefIndex, LOCAL_CRATE};
+use rustc::hir::map::blocks::FnLikeNode;
+
+/// A MIR transformation that, for each basic block, inserts a call to the software trace recorder.
+/// The arguments to the calls (crate hash, DefId and block index) identify the position to be
+/// inserted into a trace.
+///
+/// The transformation works by copying each original "user block" and replacing it with a new
+/// block -- its "shadow" -- which calls the trace recorder function, before returning to the copy.
+///
+/// For example:
+///
+/// +----+   +----+           +-----+   +-----+   +----+   +-----+   +-----+   +----+
+/// | B0 |-->| B1 |  Becomes: | B0' |-->| Rec |-->| B2 |-->| B1' |-->| Rec |-->| B3 |
+/// +----+   +----+           +-----+   +-----+   +----+   +-----+   +-----+   +----+
+///
+/// Where:
+///  * B0 and B1 are "user blocks" in the MIR before the transformation.
+///  * B0' and B1' are "shadow blocks" of B0 and B1 respectively.
+///  * B2 and B3 are copies of B0 and B1 respectively.
+///  * 'Rec' is the trace recorder function.
+///  * The block indices match the indices in the backing vector in the MIR.
+///
+/// The extra calls we insert mean that we have to allocate new local decls for the (unit) return
+/// values: one new decl for each call.
+pub struct AddYkSWTCalls(pub DefIndex);
+
+impl MirPass for AddYkSWTCalls {
+    fn run_pass<'a, 'tcx>(&self,
+                          tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                          src: MirSource,
+                          mir: &mut Mir<'tcx>) {
+        if is_untraceable(tcx, src) {
+            return;
+        }
+
+        let rec_fn_defid = tcx.get_lang_items(LOCAL_CRATE).yk_swt_rec_loc_wrap()
+            .expect("couldn't find software trace recorder function");
+
+        let unit_ty = tcx.mk_unit();
+        let u32_ty = tcx.types.u32;
+        let u64_ty = tcx.types.u64;
+
+        let mut shadow_blks = Vec::new();
+        let mut user_blks = Vec::new(); // Copies of the blocks we started with.
+        let mut new_local_decls = Vec::new();
+
+        let num_orig_local_decls = mir.local_decls.len();
+        let local_crate_hash = tcx.crate_hash(LOCAL_CRATE).as_u64();
+
+        for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+            // Copy the block.
+            let new_blk = bb_data.clone();
+            let new_blk_idx = BasicBlock::new(mir.basic_blocks().len() + user_blks.len());
+            user_blks.push(new_blk);
+
+            // Prepare to call the recorder function.
+            let ret_val = LocalDecl::new_temp(unit_ty, DUMMY_SP);
+            let ret_place = Place::Local(Local::new(num_orig_local_decls + new_local_decls.len()));
+            new_local_decls.push(ret_val);
+
+            let crate_hash_oper = Operand::Constant(box Constant {
+                span: DUMMY_SP,
+                ty: u64_ty,
+                user_ty: None,
+                literal: ty::Const::from_u64(tcx, local_crate_hash),
+            });
+
+            let def_idx_oper = Operand::Constant(box Constant {
+                span: DUMMY_SP,
+                ty: u32_ty,
+                user_ty: None,
+                literal: ty::Const::from_u32(tcx, self.0.as_raw_u32()),
+            });
+
+            let bb_oper = Operand::Constant(box Constant {
+                span: DUMMY_SP,
+                ty: u32_ty,
+                user_ty: None,
+                literal: ty::Const::from_u32(tcx, bb.index() as u32),
+            });
+
+            let rec_fn_oper = Operand::function_handle(tcx, rec_fn_defid,
+                List::empty(), DUMMY_SP);
+
+            let term_kind = TerminatorKind::Call {
+                func: rec_fn_oper,
+                args: vec![crate_hash_oper, def_idx_oper, bb_oper],
+                destination: Some((ret_place, new_blk_idx)), // Return to the copied block.
+                cleanup: None,
+                from_hir_call: false,
+            };
+
+            // Build the replacement block with the new call terminator.
+            let source_info = bb_data.terminator.clone().map(|t| t.source_info)
+                .or(Some(SourceInfo { span: DUMMY_SP, scope: OUTERMOST_SOURCE_SCOPE })).unwrap();
+            let replace_block = BasicBlockData {
+                statements: vec![],
+                terminator: Some(Terminator {
+                    source_info,
+                    kind: term_kind
+                }),
+                is_cleanup: false
+            };
+            shadow_blks.push(replace_block);
+        }
+
+        // Finally, commit our transformations.
+        mir.basic_blocks_mut().extend(user_blks);
+        mir.local_decls.extend(new_local_decls);
+        for (bb, bb_data) in shadow_blks.drain(..).enumerate() {
+            mir.basic_blocks_mut()[BasicBlock::new(bb)] = bb_data;
+        }
+    }
+}
+
+/// Given a `MirSource`, decides if it is possible for us to trace (and thus whether we should
+/// transform) the MIR. Returns `true` if we cannot trace, otherwise `false`.
+fn is_untraceable(tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource) -> bool {
+    // Never annotate anything annotated with the `#[no_trace]` attribute. This is used on tests
+    // where our pass would interfere and on the trace recorder to prevent infinite
+    // recursion.
+    //
+    // "naked functions" can't be traced because their implementations manually implement
+    // binary-level function epilogues and prologues, often using in-line assembler. We can't
+    // automatically insert our calls into such code without breaking stuff.
+    for attr in tcx.get_attrs(src.def_id).iter() {
+        if attr.check_name("no_trace") {
+            return true;
+        }
+        if attr.check_name("naked") {
+            return true;
+       }
+    }
+
+    // Similar to `#[no_trace]`, don't transform anything inside a crate marked `#![no_trace]`.
+    for attr in tcx.hir.krate_attrs() {
+        if attr.check_name("no_trace") {
+            return true;
+        }
+    }
+
+    // We can't call the software tracing function if the crate doesn't depend upon libcore because
+    // that's where the entry point to the trace recorder function lives.
+    if attr::contains_name(tcx.hir.krate_attrs(), "no_core") {
+        return true;
+    }
+
+    // Attempting to transform libcompiler_builtins leads to an undefined reference to the trace
+    // recorder wrapper `core::yk_swt::yk_swt_rec_loc_wrap`. It's not worth investigating, as this
+    // crate only contains wrapped C and ASM code that we can't transform anyway.
+    if tcx.is_compiler_builtins(LOCAL_CRATE) {
+        return true;
+    }
+
+    // We can't transform promoted items, because they are `const`, and our trace recorder isn't.
+    if let Some(_) = src.promoted {
+        return true;
+    }
+
+    // For the same reason as above, regular const functions can't be transformed.
+    let node_id = tcx.hir.as_local_node_id(src.def_id)
+        .expect("Failed to get node id");
+    if let Some(fn_like) = FnLikeNode::from_node(tcx.hir.get(node_id)) {
+        fn_like.constness() == hir::Constness::Const
+    } else {
+        true
+    }
+}

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -47,6 +47,7 @@ pub mod generator;
 pub mod inline;
 pub mod lower_128bit;
 pub mod uniform_array_move_out;
+pub mod add_yk_swt_calls;
 
 pub(crate) fn provide(providers: &mut Providers) {
     self::qualify_consts::provide(providers);
@@ -302,6 +303,7 @@ fn optimized_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx 
         &simplify::SimplifyLocals,
 
         &add_call_guards::CriticalCallEdges,
+        &add_yk_swt_calls::AddYkSWTCalls(def_id.index),
         &dump_mir::Marker("PreCodegen"),
     ]);
     tcx.alloc_mir(mir)

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -518,6 +518,10 @@ mod coresimd {
 #[cfg(all(not(stage0), not(test)))]
 pub use stdsimd::arch;
 
+/// Yorick software tracing.
+#[unstable(feature = "yk_swt", issue = "0")]
+pub mod yk_swt;
+
 // Include a number of private modules that exist solely to provide
 // the rustdoc documentation for primitive types. Using `include!`
 // because rustdoc only looks for these modules at the crate level.

--- a/src/libstd/yk_swt.rs
+++ b/src/libstd/yk_swt.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// The software trace recorder function.
+/// The `AddYkSWTCalls` MIR pass injects a call this for every MIR block. The call is done
+/// indirectly via a wrapper in libcore.
+#[cfg_attr(not(stage0), lang="yk_swt_rec_loc")]
+#[allow(unused_variables,dead_code)]
+#[cfg_attr(not(stage0), no_trace)]
+#[cfg(not(test))]
+fn rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
+    // Not implemented.
+}

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -791,6 +791,8 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("abi", Normal, Ungated),
     ("automatically_derived", Normal, Ungated),
     ("no_mangle", Normal, Ungated),
+    // Don't trace this. Disables the `AddYkSWTCalls` MIR transform.
+    ("no_trace", Whitelisted, Ungated),
     ("no_link", Normal, Ungated),
     ("derive", Normal, Ungated),
     ("should_panic", Normal, Ungated),

--- a/src/test/codegen/alloc-optimisation.rs
+++ b/src/test/codegen/alloc-optimisation.rs
@@ -10,6 +10,7 @@
 //
 // no-system-llvm
 // compile-flags: -O
+// ignore-test FIXME swt_ignore
 #![crate_type="lib"]
 
 #[no_mangle]

--- a/src/test/codegen/dealloc-no-unwind.rs
+++ b/src/test/codegen/dealloc-no-unwind.rs
@@ -10,6 +10,7 @@
 //
 // no-system-llvm
 // compile-flags: -O
+// ignore-test FIXME swt_ignore
 
 #![crate_type="lib"]
 

--- a/src/test/codegen/issue-13018.rs
+++ b/src/test/codegen/issue-13018.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME swt_ignore
 // compile-flags: -O
 
 // A drop([...].clone()) sequence on an Rc should be a no-op

--- a/src/test/codegen/issue-34947-pow-i32.rs
+++ b/src/test/codegen/issue-34947-pow-i32.rs
@@ -11,6 +11,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
+#![no_trace]
 
 // CHECK-LABEL: @issue_34947
 #[no_mangle]

--- a/src/test/codegen/issue-45222.rs
+++ b/src/test/codegen/issue-45222.rs
@@ -12,6 +12,7 @@
 // min-llvm-version 6.0
 
 #![crate_type = "lib"]
+#![no_trace]
 
 // verify that LLVM recognizes a loop involving 0..=n and will const-fold it.
 

--- a/src/test/codegen/issue-45466.rs
+++ b/src/test/codegen/issue-45466.rs
@@ -12,6 +12,7 @@
 // min-llvm-version 6.0
 
 #![crate_type="rlib"]
+#![no_trace]
 
 // CHECK-LABEL: @memzero
 // CHECK-NOT: store

--- a/src/test/codegen/match-optimizes-away.rs
+++ b/src/test/codegen/match-optimizes-away.rs
@@ -11,6 +11,7 @@
 // no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]
+#![no_trace]
 
 pub enum Three { A, B, C }
 

--- a/src/test/codegen/match.rs
+++ b/src/test/codegen/match.rs
@@ -11,6 +11,7 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![no_trace]
 
 pub enum E {
     A,

--- a/src/test/codegen/repeat-trusted-len.rs
+++ b/src/test/codegen/repeat-trusted-len.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME swt_ignore
 // compile-flags: -O
 // ignore-tidy-linelength
 // min-llvm-version 7.0

--- a/src/test/codegen/scalar-pair-bool.rs
+++ b/src/test/codegen/scalar-pair-bool.rs
@@ -11,6 +11,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
+#![no_trace]
 
 // CHECK: define { i8, i8 } @pair_bool_bool(i1 zeroext %pair.0, i1 zeroext %pair.1)
 #[no_mangle]

--- a/src/test/codegen/slice-position-bounds-check.rs
+++ b/src/test/codegen/slice-position-bounds-check.rs
@@ -11,6 +11,7 @@
 // no-system-llvm
 // compile-flags: -O -C panic=abort
 #![crate_type = "lib"]
+#![no_trace]
 
 fn search<T: Ord + Eq>(arr: &mut [T], a: &T) -> Result<usize, ()> {
     match arr.iter().position(|x| x == a) {

--- a/src/test/compile-fail/two-panic-runtimes.rs
+++ b/src/test/compile-fail/two-panic-runtimes.rs
@@ -15,9 +15,13 @@
 // aux-build:panic-runtime-lang-items.rs
 
 #![no_std]
+#![feature(lang_items)]
 
 extern crate panic_runtime_unwind;
 extern crate panic_runtime_unwind2;
 extern crate panic_runtime_lang_items;
 
 fn main() {}
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/debuginfo/associated-types.rs
+++ b/src/test/debuginfo/associated-types.rs
@@ -93,6 +93,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 trait TraitWithAssocType {
     type Type;

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -127,6 +127,8 @@
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
+#![no_trace]
+
 fn main() {
     let bool_val: bool = true;
     let bool_ref: &bool = &bool_val;

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -48,6 +48,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 enum ABC { TheA, TheB, TheC }
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -45,6 +45,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -76,6 +76,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct SomeStruct {
     x: isize,

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -50,6 +50,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let stack_val: (i16, f32) = (-14, -19f32);

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -129,6 +129,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let bool_box: Box<bool> = box true;

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -37,6 +37,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let a = box 1;

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -43,6 +43,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct StructWithSomePadding {
     x: i16,

--- a/src/test/debuginfo/c-style-enum-in-composite.rs
+++ b/src/test/debuginfo/c-style-enum-in-composite.rs
@@ -79,6 +79,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::AnEnum::{OneHundred, OneThousand, OneMillion};
 use self::AnotherEnum::{MountainView, Toronto, Vienna};

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -371,6 +371,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -298,6 +298,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/evec-in-struct.rs
+++ b/src/test/debuginfo/evec-in-struct.rs
@@ -64,6 +64,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct NoPadding1 {
     x: [u32; 3],

--- a/src/test/debuginfo/extern-c-fn.rs
+++ b/src/test/debuginfo/extern-c-fn.rs
@@ -51,6 +51,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 
 #[no_mangle]

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
@@ -38,6 +38,7 @@
 // gdbr-check:$5 = gdb_pretty_struct_and_enums_pre_gdb_7_7::CStyleEnum::CStyleEnumVar3
 
 #![allow(dead_code, unused_variables)]
+#![no_trace]
 
 struct RegularStruct {
     the_first_field: isize,

--- a/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -75,6 +75,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 // This test case makes sure that we get correct type descriptions for the enum
 // discriminant of different instantiations of the same generic enum type where,

--- a/src/test/debuginfo/generic-function.rs
+++ b/src/test/debuginfo/generic-function.rs
@@ -86,6 +86,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 #[derive(Clone)]
 struct Struct {

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -35,6 +35,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/generic-struct.rs
+++ b/src/test/debuginfo/generic-struct.rs
@@ -51,6 +51,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct AGenericStruct<TKey, TValue> {
     key: TKey,

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -54,6 +54,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/include_string.rs
+++ b/src/test/debuginfo/include_string.rs
@@ -40,6 +40,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 // This test case makes sure that debug info does not ICE when include_str is
 // used multiple times (see issue #11322).

--- a/src/test/debuginfo/issue-12886.rs
+++ b/src/test/debuginfo/issue-12886.rs
@@ -16,11 +16,12 @@
 
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]35[...]s
+// gdb-check:[...]36[...]s
 // gdb-command:continue
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 // IF YOU MODIFY THIS FILE, BE CAREFUL TO ADAPT THE LINE NUMBERS IN THE DEBUGGER COMMANDS
 

--- a/src/test/debuginfo/lexical-scope-in-for-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-for-loop.rs
@@ -94,6 +94,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-if.rs
+++ b/src/test/debuginfo/lexical-scope-in-if.rs
@@ -151,6 +151,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-match.rs
+++ b/src/test/debuginfo/lexical-scope-in-match.rs
@@ -145,6 +145,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct Struct {
     x: isize,

--- a/src/test/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-stack-closure.rs
@@ -77,6 +77,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -146,6 +146,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-unique-closure.rs
@@ -78,6 +78,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-while.rs
+++ b/src/test/debuginfo/lexical-scope-in-while.rs
@@ -146,6 +146,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -122,6 +122,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 macro_rules! trivial {
     ($e1:expr) => ($e1)

--- a/src/test/debuginfo/multiple-functions-equal-var-names.rs
+++ b/src/test/debuginfo/multiple-functions-equal-var-names.rs
@@ -49,6 +49,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn function_one() {
     let abc = 10101;

--- a/src/test/debuginfo/multiple-functions.rs
+++ b/src/test/debuginfo/multiple-functions.rs
@@ -49,6 +49,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn function_one() {
     let a = 10101;

--- a/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -107,6 +107,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -26,6 +26,7 @@
 #![feature(no_debug)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 #[inline(never)]
 fn id<T>(x: T) -> T {x}

--- a/src/test/debuginfo/packed-struct-with-destructor.rs
+++ b/src/test/debuginfo/packed-struct-with-destructor.rs
@@ -91,6 +91,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -72,6 +72,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/pretty-huge-vec.rs
+++ b/src/test/debuginfo/pretty-huge-vec.rs
@@ -27,6 +27,7 @@
 
 
 #![allow(unused_variables)]
+#![no_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -76,6 +76,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Opt::{Empty, Val};
 

--- a/src/test/debuginfo/shadowed-argument.rs
+++ b/src/test/debuginfo/shadowed-argument.rs
@@ -66,6 +66,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn a_function(x: bool, y: bool) {
     zzz(); // #break

--- a/src/test/debuginfo/shadowed-variable.rs
+++ b/src/test/debuginfo/shadowed-variable.rs
@@ -91,6 +91,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -67,6 +67,7 @@
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 #![feature(repr_simd)]
+#![no_trace]
 
 #[repr(simd)]
 struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);

--- a/src/test/debuginfo/simple-lexical-scope.rs
+++ b/src/test/debuginfo/simple-lexical-scope.rs
@@ -87,6 +87,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/struct-in-struct.rs
+++ b/src/test/debuginfo/struct-in-struct.rs
@@ -69,6 +69,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct Simple {
     x: i32

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -55,6 +55,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/struct-with-destructor.rs
+++ b/src/test/debuginfo/struct-with-destructor.rs
@@ -56,6 +56,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct NoDestructor {
     x: i32,

--- a/src/test/debuginfo/tuple-in-struct.rs
+++ b/src/test/debuginfo/tuple-in-struct.rs
@@ -54,6 +54,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct NoPadding1 {
     x: (i32, i32),

--- a/src/test/debuginfo/tuple-in-tuple.rs
+++ b/src/test/debuginfo/tuple-in-tuple.rs
@@ -72,6 +72,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 fn main() {
     let no_padding1: ((u32, u32), u32, u32) = ((0, 1), 2, 3);

--- a/src/test/debuginfo/tuple-struct.rs
+++ b/src/test/debuginfo/tuple-struct.rs
@@ -78,6 +78,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 struct NoPadding16(u16, i16);
 struct NoPadding32(i32, f32, u32);

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -55,6 +55,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -49,6 +49,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -97,6 +97,8 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
+#![no_trace]
+
 
 struct Struct {
     a: isize,

--- a/src/test/incremental/change_add_field/struct_point.rs
+++ b/src/test/incremental/change_add_field/struct_point.rs
@@ -21,6 +21,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
+#![no_trace]
 
 // These are expected to require codegen.
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]

--- a/src/test/incremental/change_private_fn/struct_point.rs
+++ b/src/test/incremental/change_private_fn/struct_point.rs
@@ -19,6 +19,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
+#![no_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_private_fn_cc/struct_point.rs
+++ b/src/test/incremental/change_private_fn_cc/struct_point.rs
@@ -20,6 +20,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
+#![no_trace]
 
 #![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
 #![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]

--- a/src/test/incremental/change_private_impl_method/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method/struct_point.rs
@@ -19,6 +19,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
+#![no_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_private_impl_method_cc/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method_cc/struct_point.rs
@@ -20,6 +20,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
+#![no_trace]
 
 #![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
 #![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]

--- a/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -18,6 +18,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
+#![no_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -18,6 +18,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
+#![no_trace]
 
 // These are expected to require codegen.
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]

--- a/src/test/incremental/change_symbol_export_status.rs
+++ b/src/test/incremental/change_symbol_export_status.rs
@@ -16,6 +16,7 @@
 
 #![rustc_partition_codegened(module="change_symbol_export_status-mod1", cfg="rpass2")]
 #![rustc_partition_reused(module="change_symbol_export_status-mod2", cfg="rpass2")]
+#![no_trace]
 
 // This test case makes sure that a change in symbol visibility is detected by
 // our dependency tracking. We do this by changing a module's visibility to

--- a/src/test/incremental/hashes/closure_expressions.rs
+++ b/src/test/incremental/hashes/closure_expressions.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 // Change closure body ---------------------------------------------------------

--- a/src/test/incremental/hashes/enum_constructors.rs
+++ b/src/test/incremental/hashes/enum_constructors.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 pub enum Enum {

--- a/src/test/incremental/hashes/for_loops.rs
+++ b/src/test/incremental/hashes/for_loops.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/function_interfaces.rs
+++ b/src/test/incremental/hashes/function_interfaces.rs
@@ -26,6 +26,7 @@
 #![feature(linkage)]
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]
+#![no_trace]
 
 
 // Add Parameter ---------------------------------------------------------------

--- a/src/test/incremental/hashes/if_expressions.rs
+++ b/src/test/incremental/hashes/if_expressions.rs
@@ -24,6 +24,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 // Change condition (if) -------------------------------------------------------
 #[cfg(cfail1)]

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -24,6 +24,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 pub struct Foo;
 

--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -24,6 +24,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 // Change Name -----------------------------------------------------------------
 #[cfg(cfail1)]

--- a/src/test/incremental/hashes/loop_expressions.rs
+++ b/src/test/incremental/hashes/loop_expressions.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/struct_constructors.rs
+++ b/src/test/incremental/hashes/struct_constructors.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 pub struct RegularStruct {

--- a/src/test/incremental/hashes/while_let_loops.rs
+++ b/src/test/incremental/hashes/while_let_loops.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/while_loops.rs
+++ b/src/test/incremental/hashes/while_loops.rs
@@ -23,6 +23,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/issue-38222.rs
+++ b/src/test/incremental/issue-38222.rs
@@ -24,6 +24,8 @@
 // be re-used, so checking that this module was re-used is sufficient.
 #![rustc_partition_reused(module="issue_38222", cfg="rpass2")]
 
+#![no_trace]
+
 //[rpass1] compile-flags: -C debuginfo=1
 //[rpass2] compile-flags: -C debuginfo=1
 

--- a/src/test/incremental/issue-42602.rs
+++ b/src/test/incremental/issue-42602.rs
@@ -21,6 +21,7 @@
 // compile-pass
 
 #![feature(rustc_attrs)]
+#![no_trace]
 
 fn main() {
     a::foo();

--- a/src/test/incremental/krate-inherent.rs
+++ b/src/test/incremental/krate-inherent.rs
@@ -16,6 +16,7 @@
 #![feature(rustc_attrs)]
 #![rustc_partition_reused(module="krate_inherent-x", cfg="cfail2")]
 #![crate_type = "rlib"]
+#![no_trace]
 
 pub mod x {
     pub struct Foo;

--- a/src/test/incremental/krate-inlined.rs
+++ b/src/test/incremental/krate-inlined.rs
@@ -18,6 +18,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![rustc_partition_reused(module="krate_inlined-x", cfg="rpass2")]
+#![no_trace]
 
 fn main() {
     x::method();

--- a/src/test/incremental/remapped_paths_cc/main.rs
+++ b/src/test/incremental/remapped_paths_cc/main.rs
@@ -16,6 +16,7 @@
 // are changed, even when the change happens in an external crate.
 
 #![feature(rustc_attrs)]
+#![no_trace]
 
 #![rustc_partition_reused(module="main", cfg="rpass2")]
 #![rustc_partition_reused(module="main-some_mod", cfg="rpass2")]

--- a/src/test/incremental/remove-private-item-cross-crate/main.rs
+++ b/src/test/incremental/remove-private-item-cross-crate/main.rs
@@ -17,6 +17,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type = "bin"]
+#![no_trace]
 
 #![rustc_partition_reused(module="main", cfg="rpass2")]
 

--- a/src/test/incremental/spans_in_type_debuginfo.rs
+++ b/src/test/incremental/spans_in_type_debuginfo.rs
@@ -18,6 +18,7 @@
 #![rustc_partition_reused(module="spans_in_type_debuginfo-enums", cfg="rpass2")]
 
 #![feature(rustc_attrs)]
+#![no_trace]
 
 mod structs {
     #[cfg(rpass1)]

--- a/src/test/incremental/spike.rs
+++ b/src/test/incremental/spike.rs
@@ -20,6 +20,7 @@
 #![rustc_partition_reused(module="spike", cfg="rpass2")]
 #![rustc_partition_codegened(module="spike-x", cfg="rpass2")]
 #![rustc_partition_reused(module="spike-y", cfg="rpass2")]
+#![no_trace]
 
 mod x {
     pub struct X {

--- a/src/test/incremental/string_constant.rs
+++ b/src/test/incremental/string_constant.rs
@@ -15,6 +15,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]
+#![no_trace]
 
 // Here the only thing which changes is the string constant in `x`.
 // Therefore, the compiler deduces (correctly) that typeck is not

--- a/src/test/incremental/thinlto/cgu_invalidated_via_import.rs
+++ b/src/test/incremental/thinlto/cgu_invalidated_via_import.rs
@@ -19,6 +19,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-foo",
                             cfg="cfail2",

--- a/src/test/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
+++ b/src/test/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
@@ -18,6 +18,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
+#![no_trace]
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-foo",
                             cfg="cfail2",

--- a/src/test/mir-opt/inline-any-operand.rs
+++ b/src/test/mir-opt/inline-any-operand.rs
@@ -12,6 +12,8 @@
 
 // Tests that MIR inliner works for any operand
 
+#![no_trace]
+
 fn main() {
     println!("{}", bar());
 }

--- a/src/test/mir-opt/inline-closure-borrows-arg.rs
+++ b/src/test/mir-opt/inline-closure-borrows-arg.rs
@@ -9,9 +9,12 @@
 // except according to those terms.
 
 // compile-flags: -Z span_free_formats
+// ignore-test FIXME swt_ignore
 
 // Tests that MIR inliner can handle closure arguments,
 // even when (#45894)
+
+#![no_trace]
 
 fn main() {
     println!("{}", foo(0, &14));

--- a/src/test/mir-opt/inline-closure.rs
+++ b/src/test/mir-opt/inline-closure.rs
@@ -9,8 +9,11 @@
 // except according to those terms.
 
 // compile-flags: -Z span_free_formats
+// ignore-test FIXME swt_ignore
 
 // Tests that MIR inliner can handle closure arguments. (#45894)
+
+#![no_trace]
 
 fn main() {
     println!("{}", foo(0, 14));

--- a/src/test/mir-opt/inline-trait-method_2.rs
+++ b/src/test/mir-opt/inline-trait-method_2.rs
@@ -1,5 +1,7 @@
 // compile-flags: -Z span_free_formats -Z mir-opt-level=3
 
+#![no_trace]
+
 #[inline]
 fn test(x: &dyn X) -> bool {
     x.y()

--- a/src/test/run-make-fulldeps/inline-always-many-cgu/foo.rs
+++ b/src/test/run-make-fulldeps/inline-always-many-cgu/foo.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![crate_type = "lib"]
+#![no_trace]
 
 pub mod a {
     #[inline(always)]

--- a/src/test/run-make-fulldeps/issue-51671/app.rs
+++ b/src/test/run-make-fulldeps/issue-51671/app.rs
@@ -16,6 +16,9 @@
 use core::alloc::Layout;
 use core::panic::PanicInfo;
 
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}
+
 #[panic_handler]
 fn panic(_: &PanicInfo) -> ! {
     loop {}

--- a/src/test/run-make-fulldeps/issue-53964/app.rs
+++ b/src/test/run-make-fulldeps/issue-53964/app.rs
@@ -3,6 +3,10 @@
 #![no_std]
 
 #![deny(unused_extern_crates)]
+#![feature(lang_items)]
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}
 
 // `panic` provides a `panic_handler` so it shouldn't trip the `unused_extern_crates` lint
 extern crate panic;

--- a/src/test/run-make-fulldeps/panic-impl-transitive/panic-impl-provider.rs
+++ b/src/test/run-make-fulldeps/panic-impl-transitive/panic-impl-provider.rs
@@ -10,6 +10,10 @@
 
 #![crate_type = "rlib"]
 #![no_std]
+#![feature(lang_items)]
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}
 
 use core::panic::PanicInfo;
 

--- a/src/test/run-pass/stack-probes-lto.rs
+++ b/src/test/run-pass/stack-probes-lto.rs
@@ -24,4 +24,6 @@
 // compile-flags: -C lto
 // no-prefer-dynamic
 
+extern crate core;
+
 include!("stack-probes.rs");

--- a/src/test/run-pass/thinlto/thin-lto-inlines.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines.rs
@@ -18,6 +18,8 @@
 // praying two functions go into separate codegen units and then assuming that
 // if inlining *doesn't* happen the first byte of the functions will differ.
 
+#![no_trace]
+
 pub fn foo() -> u32 {
     bar::bar()
 }

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler, panic_handler, lang_items)]
 #![no_std]
 #![no_main]
 
@@ -26,3 +26,6 @@ fn oom(
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler, panic_handler, lang_items)]
 #![no_std]
 #![no_main]
 
@@ -25,3 +25,6 @@ fn oom(
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler, panic_handler, lang_items)]
 #![no_std]
 #![no_main]
 
@@ -23,3 +23,6 @@ fn oom() -> ! { //~ ERROR function should have one argument
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/consts/const-eval/const_panic_libcore_main.rs
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_main.rs
@@ -34,3 +34,6 @@ fn eh_unwind_resume() {}
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/missing/missing-alloc_error_handler.rs
+++ b/src/test/ui/missing/missing-alloc_error_handler.rs
@@ -13,7 +13,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler, alloc)]
+#![feature(panic_handler, alloc_error_handler, alloc, lang_items)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
@@ -31,3 +31,6 @@ unsafe impl core::alloc::GlobalAlloc for MyAlloc {
     unsafe fn alloc(&self, _: core::alloc::Layout) -> *mut u8 { 0 as _ }
     unsafe fn dealloc(&self, _: *mut u8, _: core::alloc::Layout) {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/missing/missing-allocator.rs
+++ b/src/test/ui/missing/missing-allocator.rs
@@ -13,7 +13,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler, alloc)]
+#![feature(panic_handler, alloc_error_handler, alloc, lang_items)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
@@ -26,3 +26,6 @@ fn oom(_: core::alloc::Layout) -> ! {
 }
 
 extern crate alloc;
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/no_owned_box_lang_item.rs
+++ b/src/test/ui/no_owned_box_lang_item.rs
@@ -24,3 +24,4 @@ fn main() {
 #[lang = "eh_personality"] extern fn eh_personality() {}
 #[lang = "eh_unwind_resume"] extern fn eh_unwind_resume() {}
 #[lang = "panic_impl"] fn panic_impl(panic: &PanicInfo) -> ! { loop {} }
+#[lang = "yk_swt_rec_loc"] fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-1.rs
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-1.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 use core::panic::PanicInfo;
 
@@ -21,3 +22,6 @@ fn panic(
 ) -> () //~ ERROR return type should be `!`
 {
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-1.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-1.stderr
@@ -1,11 +1,11 @@
 error: return type should be `!`
-  --> $DIR/panic-handler-bad-signature-1.rs:21:6
+  --> $DIR/panic-handler-bad-signature-1.rs:22:6
    |
 LL | ) -> () //~ ERROR return type should be `!`
    |      ^^
 
 error: argument should be `&PanicInfo`
-  --> $DIR/panic-handler-bad-signature-1.rs:20:11
+  --> $DIR/panic-handler-bad-signature-1.rs:21:11
    |
 LL |     info: PanicInfo, //~ ERROR argument should be `&PanicInfo`
    |           ^^^^^^^^^

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-2.rs
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-2.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 use core::panic::PanicInfo;
 
@@ -22,3 +23,6 @@ fn panic(
 {
     loop {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-2.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-2.stderr
@@ -1,5 +1,5 @@
 error: argument should be `&PanicInfo`
-  --> $DIR/panic-handler-bad-signature-2.rs:20:11
+  --> $DIR/panic-handler-bad-signature-2.rs:21:11
    |
 LL |     info: &'static PanicInfo, //~ ERROR argument should be `&PanicInfo`
    |           ^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-3.rs
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-3.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 use core::panic::PanicInfo;
 
@@ -19,3 +20,6 @@ use core::panic::PanicInfo;
 fn panic() -> ! { //~ ERROR function should have one argument
     loop {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-3.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-3.stderr
@@ -1,5 +1,5 @@
 error: function should have one argument
-  --> $DIR/panic-handler-bad-signature-3.rs:19:1
+  --> $DIR/panic-handler-bad-signature-3.rs:20:1
    |
 LL | fn panic() -> ! { //~ ERROR function should have one argument
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-4.rs
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-4.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 use core::panic::PanicInfo;
 
@@ -20,3 +21,6 @@ fn panic<T>(pi: &PanicInfo) -> ! {
     //~^ ERROR should have no type parameters
     loop {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-4.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-4.stderr
@@ -1,5 +1,5 @@
 error: should have no type parameters
-  --> $DIR/panic-handler-bad-signature-4.rs:19:1
+  --> $DIR/panic-handler-bad-signature-4.rs:20:1
    |
 LL | / fn panic<T>(pi: &PanicInfo) -> ! {
 LL | |     //~^ ERROR should have no type parameters

--- a/src/test/ui/panic-handler/panic-handler-duplicate.rs
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.rs
@@ -25,3 +25,6 @@ fn panic(info: &PanicInfo) -> ! {
 fn panic2(info: &PanicInfo) -> ! { //~ ERROR duplicate lang item found: `panic_impl`.
     loop {}
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-wrong-location.rs
+++ b/src/test/ui/panic-handler/panic-handler-wrong-location.rs
@@ -12,7 +12,11 @@
 
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 #[panic_handler]
 #[no_mangle]
 static X: u32 = 42;
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-handler/panic-handler-wrong-location.stderr
+++ b/src/test/ui/panic-handler/panic-handler-wrong-location.stderr
@@ -1,5 +1,5 @@
 error[E0718]: `panic_impl` language item must be applied to a function
-  --> $DIR/panic-handler-wrong-location.rs:16:1
+  --> $DIR/panic-handler-wrong-location.rs:17:1
    |
 LL | #[panic_handler]
    | ^^^^^^^^^^^^^^^^ attribute should be applied to a function, not a static item

--- a/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
+++ b/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
@@ -17,9 +17,13 @@
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
+#![feature(lang_items)]
 
 extern crate wants_panic_runtime_unwind;
 extern crate wants_panic_runtime_abort;
 extern crate panic_runtime_lang_items;
 
 fn main() {}
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-runtime/want-unwind-got-abort.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort.rs
@@ -14,8 +14,12 @@
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
+#![feature(lang_items)]
 
 extern crate panic_runtime_abort;
 extern crate panic_runtime_lang_items;
 
 fn main() {}
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
@@ -15,8 +15,12 @@
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
+#![feature(lang_items)]
 
 extern crate wants_panic_runtime_abort;
 extern crate panic_runtime_lang_items;
 
 fn main() {}
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}

--- a/src/test/ui/range/issue-54505-no-std.rs
+++ b/src/test/ui/range/issue-54505-no-std.rs
@@ -55,3 +55,6 @@ fn main() {
     //~| HELP consider borrowing here
     //~| SUGGESTION &(..=42)
 }
+
+#[lang = "yk_swt_rec_loc"]
+fn yk_swt_rec_loc(_crate_hash: u64, _def_idx: u32, _bb: u32) {}


### PR DESCRIPTION
Here's the long-awaited PR for the beginnings of software tracing.

See the commit messages for a description of the changes.

Notes:
 - The body of the software tracing function is not yet implemented. This will come next. I plan for it to store the locations it receives into a thread local vector. A function will then be implemented to acquire the contents.

 - I've decided not to test any of our new behaviours in existing tests, as we should eventually have our own tests if we decide to keep this code. I will raise an issue if/when we merge.

 - At some point in the future, we will have to have a compile-time switch to choose between software or hardware tracing. We would need some kind of conditional ignore flag for tests. Any test I've marked `FIXME ignore_swt` can be run if software tracing was not built in. Note that the choice between hardware or software tracing will need to be compile-time, as the standard library must have been annotated if we want software tracing. In a hardware tracing scenario, we don't want the overhead of the calls to the software trace function.

Comments? Questions? I expect there will be many.

(Happy new year, for later!)