### PR TITLE
Preliminary trace recording.

### DIFF
--- a/src/libstd/yk_swt.rs
+++ b/src/libstd/yk_swt.rs
@@ -7,6 +7,45 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use ::cell::RefCell;
+use ::fmt;
+
+#[allow(missing_docs)]
+/// A block location in the Rust MIR.
+pub struct MirLoc {
+    pub crate_hash: u64,
+    pub def_idx: u32,
+    pub bb_idx: u32,
+}
+
+impl fmt::Debug for MirLoc {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "loc<{}, {}, {}>", self.crate_hash, self.def_idx, self.bb_idx)
+    }
+}
+
+thread_local! {
+    /// The software trace currently being collected (if any).
+    /// When `Some`, a tracing is enabled, otherwise tracing is disabled.
+    pub static TRACE: RefCell<Option<Vec<MirLoc>>> = RefCell::new(None);
+}
+
+/// Start software tracing.
+#[cfg_attr(not(stage0), no_trace)]
+pub fn start_tracing() {
+    TRACE.with(|rc| {
+        let mut trace_o = rc.borrow_mut();
+        match *trace_o {
+            Some(_) => panic!("tracing was already started for this thread!"),
+            None => *trace_o = Some(Vec::new()),
+        }
+    });
+}
+
+// FIXME Anything used in `rec_loc` below cannot itself be traced, or we get infinite recursion. To
+// work sround this, many crates are ignored by the software tracing MIR pass (see
+// librustc_mir/transform/add_yk_swt_calls.rs). Consider re-implementing the trace recorder in C?
+
 /// The software trace recorder function.
 /// The `AddYkSWTCalls` MIR pass injects a call this for every MIR block. The call is done
 /// indirectly via a wrapper in libcore.
@@ -15,5 +54,23 @@
 #[cfg_attr(not(stage0), no_trace)]
 #[cfg(not(test))]
 fn rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
-    // Not implemented.
+    TRACE.with(|rc| {
+        let mut trace_o = rc.borrow_mut();
+        match trace_o.as_mut() {
+            Some(trace) => trace.push(MirLoc{crate_hash, def_idx, bb_idx}),
+            None => (), // Tracing is disabled, do nothing.
+        }
+    });
+}
+
+/// Stop tracing and return the trace.
+#[cfg_attr(not(stage0), no_trace)]
+pub fn stop_tracing() -> Vec<MirLoc> {
+    TRACE.with(|rc| {
+        let trace_o = rc.borrow_mut().take();
+        if trace_o.is_none() {
+            panic!("tracing not started on this thread");
+        }
+        trace_o.unwrap()
+    })
 }

--- a/src/libstd/yk_swt.rs
+++ b/src/libstd/yk_swt.rs
@@ -43,7 +43,7 @@ pub fn start_tracing() {
 }
 
 // FIXME Anything used in `rec_loc` below cannot itself be traced, or we get infinite recursion. To
-// work sround this, many crates are ignored by the software tracing MIR pass (see
+// work around this, many crates are ignored by the software tracing MIR pass (see
 // librustc_mir/transform/add_yk_swt_calls.rs). Consider re-implementing the trace recorder in C?
 
 /// The software trace recorder function.
@@ -58,7 +58,7 @@ fn rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
         let mut trace_o = rc.borrow_mut();
         match trace_o.as_mut() {
             Some(trace) => trace.push(MirLoc{crate_hash, def_idx, bb_idx}),
-            None => (), // Tracing is disabled, do nothing.
+            None => (), // We are not currently tracing, do nothing.
         }
     });
 }
@@ -67,10 +67,6 @@ fn rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
 #[cfg_attr(not(stage0), no_trace)]
 pub fn stop_tracing() -> Vec<MirLoc> {
     TRACE.with(|rc| {
-        let trace_o = rc.borrow_mut().take();
-        if trace_o.is_none() {
-            panic!("tracing not started on this thread");
-        }
-        trace_o.unwrap()
+        rc.borrow_mut().take().expect("tracing not started on this thread")
     })
 }

--- a/src/test/run-fail/yk_swt/trace-already-started.rs
+++ b/src/test/run-fail/yk_swt/trace-already-started.rs
@@ -1,0 +1,19 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: thread 'main' panicked at 'tracing was already started for this thread!'
+
+#![feature(yk_swt)]
+
+use std::yk_swt::{start_tracing, stop_tracing};
+
+pub fn main() {
+    start_tracing();
+    start_tracing(); // Can't call a second time without a stop_tracing() first.
+}

--- a/src/test/run-fail/yk_swt/trace-not-started.rs
+++ b/src/test/run-fail/yk_swt/trace-not-started.rs
@@ -1,0 +1,19 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: thread 'main' panicked at 'tracing not started on this thread'
+
+#![feature(yk_swt)]
+
+use std::yk_swt::{start_tracing, stop_tracing};
+
+pub fn main() {
+    // Missing start_tracing();
+    let _ = stop_tracing();
+}

--- a/src/test/run-pass/signal-alternate-stack-cleanup.rs
+++ b/src/test/run-pass/signal-alternate-stack-cleanup.rs
@@ -16,6 +16,10 @@
 // ignore-wasm32-bare no libc
 // ignore-windows
 
+// Software tracing breaks this test as the thread local used to record the trace becomes valid at
+// atexit() time.
+#![no_trace]
+
 #![feature(libc)]
 extern crate libc;
 

--- a/src/test/run-pass/thinlto/thin-lto-inlines2.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines2.rs
@@ -20,6 +20,8 @@
 // praying two functions go into separate codegen units and then assuming that
 // if inlining *doesn't* happen the first byte of the functions will differ.
 
+#![no_trace]
+
 extern crate thin_lto_inlines_aux as bar;
 
 pub fn foo() -> u32 {

--- a/src/test/run-pass/yk_swt/collect-trace.rs
+++ b/src/test/run-pass/yk_swt/collect-trace.rs
@@ -20,7 +20,7 @@ pub fn main() {
 
 #[inline(never)]
 fn work() -> u64{
-    let mut res = 47;
+    let mut res = 100;
     for i in 0..10 {
         res += res / 2 + i;
     }

--- a/src/test/run-pass/yk_swt/collect-trace.rs
+++ b/src/test/run-pass/yk_swt/collect-trace.rs
@@ -1,0 +1,28 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(yk_swt)]
+
+use std::yk_swt::{start_tracing, stop_tracing};
+
+pub fn main() {
+    start_tracing();
+    let _ = work();
+    let trace = stop_tracing();
+    assert!(!trace.is_empty());
+}
+
+#[inline(never)]
+fn work() -> u64{
+    let mut res = 47;
+    for i in 0..10 {
+        res += res / 2 + i;
+    }
+    res
+}


### PR DESCRIPTION
This shows that we can store MIR locations into a thread local vector at runtime.

It's a quick and dirty implementation that disables tracing for a bunch of crates that ideally we probably do want to trace at some point. As discussed on IRC, we are going to live with this compromise until a later date, where we might (e.g.) implement the trace recorder in another language that the MIR pass can't see.

I've added some tests of our own too.

I've run the smoke test subset of the rustc tests at stage one and fixed a few failures. Let's see what happens in a full run.

Any comments in the meantime?