### PR TITLE
The beginnings of a new "TIR" serialiser.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "filetime"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1651,14 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2334,6 +2347,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.7"
+source = "git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a#40b3d480b20961e6eeceb416b32bcd0a3383846a"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.14.0"
+source = "git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a#40b3d480b20961e6eeceb416b32bcd0a3383846a"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
@@ -2508,6 +2540,7 @@ dependencies = [
  "rustc_codegen_ssa 0.0.0",
  "rustc_driver 0.0.0",
  "rustc_target 0.0.0",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2615,7 +2648,6 @@ dependencies = [
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_llvm 0.0.0",
- "rustc_yk_sections 0.0.0",
 ]
 
 [[package]]
@@ -2719,8 +2751,6 @@ dependencies = [
  "rustc_target 0.0.0",
  "rustc_traits 0.0.0",
  "rustc_typeck 0.0.0",
- "rustc_yk_link 0.0.0",
- "rustc_yk_sections 0.0.0",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2784,7 +2814,6 @@ dependencies = [
  "rustc_resolve 0.0.0",
  "rustc_traits 0.0.0",
  "rustc_typeck 0.0.0",
- "rustc_yk_link 0.0.0",
  "rustc_yk_sections 0.0.0",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",
@@ -3033,10 +3062,10 @@ version = "0.0.0"
 name = "rustc_yk_sections"
 version = "0.0.0"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_codegen_utils 0.0.0",
  "rustc_yk_link 0.0.0",
+ "ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)",
 ]
 
 [[package]]
@@ -4012,6 +4041,16 @@ name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "ykpack"
+version = "0.1.0"
+source = "git+https://github.com/softdevteam/ykpack#e0fd6162b9522fd04b6bbb77a232986c4ea5c257"
+dependencies = [
+ "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
@@ -4086,6 +4125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
@@ -4166,6 +4206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c281318d992e4432cfa799969467003d05921582a7489a8325e37f8a450d5113"
@@ -4234,6 +4275,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9dba7390427aefa953608429701e3665192ca810ba8ae09301e001b7c7bed0"
 "checksum rls-span 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33d66f1d6c6ccd5c98029f162544131698f6ebb61d8c697681cac409dcd08805"
 "checksum rls-vfs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72d56425bd5aa86d9d4372b76f0381d3b4bda9c0220e71956c9fcc929f45c1f1"
+"checksum rmp 0.8.7 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)" = "<none>"
+"checksum rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)" = "<none>"
 "checksum rustc-ap-arena 373.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8be999235b541fc8eb54901b66e899a06076709ac5f53d6b2c5c59d29ad54780"
 "checksum rustc-ap-graphviz 373.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "532b5df15ca1a19a42815e37e521a20a7632b86b36868d1447932f8476f8f789"
 "checksum rustc-ap-rustc_cratesio_shim 373.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c388afe1ef810013c878bdf9073ab1ae28dc49e9325863b351afb10acf4cc46e"
@@ -4345,3 +4388,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xz2 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "df8bf41d3030c3577c9458fd6640a05afbf43b150d0b531b16bd77d3f794f27a"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+"checksum ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)" = "<none>"

--- a/README_YORICK.md
+++ b/README_YORICK.md
@@ -1,4 +1,0 @@
-# Yorick-specific Notes
-
-To enable the experimental `.yk_mir_cfg` ELF section, set `YK_DEBUG_SECTIONS`
-in your environment.

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -15,7 +15,6 @@ cc = "1.0.1" # Used to locate MSVC
 num_cpus = "1.0"
 rustc-demangle = "0.1.4"
 rustc_llvm = { path = "../librustc_llvm" }
-rustc_yk_sections = { path = "../librustc_yk_sections" }
 memmap = "0.6"
 
 [features]

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -24,7 +24,6 @@ use rustc::hir::def_id::CrateNum;
 use tempfile::{Builder as TempFileBuilder, TempDir};
 use rustc_target::spec::{PanicStrategy, RelroLevel, LinkerFlavor};
 use rustc_data_structures::fx::FxHashSet;
-use rustc_yk_sections::with_yk_debug_sections;
 
 use std::ascii;
 use std::char;
@@ -545,12 +544,10 @@ fn link_natively(sess: &Session,
         cmd.args(args);
     }
 
-    // Link Yorick objects in.
-    if with_yk_debug_sections() {
-        if crate_type == config::CrateType::Executable {
-            cmd.arg("-Wl,--no-gc-sections");
-            cmd.args(sess.yk_link_objects.borrow().iter().map(|o| o.path()));
-        }
+    // Link Yorick objects into executables.
+    if crate_type == config::CrateType::Executable {
+        cmd.arg("-Wl,--no-gc-sections");
+        cmd.args(sess.yk_link_objects.borrow().iter().map(|o| o.path()));
     }
 
     for &(ref k, ref v) in &sess.target.target.options.link_env {

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -33,8 +33,6 @@ rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_traits = { path = "../librustc_traits" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_typeck = { path = "../librustc_typeck" }
-rustc_yk_sections = { path = "../librustc_yk_sections" }
-rustc_yk_link = { path = "../librustc_yk_link" }
 rustc_interface = { path = "../librustc_interface" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -50,8 +50,6 @@ extern crate log;
 extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;
-extern crate rustc_yk_sections;
-extern crate rustc_yk_link;
 
 use pretty::{PpMode, UserIdentifiedItem};
 

--- a/src/librustc_interface/Cargo.toml
+++ b/src/librustc_interface/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 rustc_yk_sections = { path = "../librustc_yk_sections" }
-rustc_yk_link = { path = "../librustc_yk_link" }
 log = "0.4"
 rustc-rayon = "0.1.1"
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -12,5 +12,5 @@ test = false
 [dependencies]
 rustc = { path = "../librustc" }
 rustc_yk_link = { path = "../librustc_yk_link" }
+ykpack = { git = "https://github.com/softdevteam/ykpack" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
-byteorder = "1.2"

--- a/src/librustc_yk_sections/lib.rs
+++ b/src/librustc_yk_sections/lib.rs
@@ -12,16 +12,6 @@
 extern crate rustc;
 extern crate rustc_yk_link;
 extern crate rustc_codegen_utils;
-extern crate byteorder;
-
-use std::env;
-
-/// Are Yorick debug sections enabled?
-pub fn with_yk_debug_sections() -> bool {
-    match env::var("YK_DEBUG_SECTIONS") {
-        Ok(_) => true,
-        _ => false,
-    }
-}
+extern crate ykpack;
 
 pub mod mir_cfg;

--- a/src/rustc/Cargo.toml
+++ b/src/rustc/Cargo.toml
@@ -12,6 +12,10 @@ path = "rustc.rs"
 rustc_target = { path = "../librustc_target" }
 rustc_driver = { path = "../librustc_driver" }
 
+# This is not a real dependency. It's just needed for linkage disambiguation.
+# See the librustc Cargo.toml for more.
+unicode-width = "0.1.5"
+
 # Make sure rustc_codegen_ssa ends up in the sysroot, because this
 # crate is intended to be used by codegen backends, which may not be in-tree.
 rustc_codegen_ssa = { path = "../librustc_codegen_ssa" }

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -6,6 +6,10 @@ use std::path::Path;
 /// List of whitelisted sources for packages.
 const WHITELISTED_SOURCES: &[&str] = &[
     "\"registry+https://github.com/rust-lang/crates.io-index\"",
+    // The following are needed for Yorick whilst we use an unreleased revision not on crates.io.
+    "\"git+https://github.com/3Hren/msgpack-rust?\
+        rev=40b3d480b20961e6eeceb416b32bcd0a3383846a#40b3d480b20961e6eeceb416b32bcd0a3383846a\"",
+    "\"git+https://github.com/softdevteam/ykpack#e0fd6162b9522fd04b6bbb77a232986c4ea5c257\"",
 ];
 
 /// Checks for external package sources.


### PR DESCRIPTION
This replaces the custom MIR serialiser, which a serde-based TIR
(tracing IR) serialiser. The change of name is to signify that we are
actually implementing our own IR now, not just a mirror of MIR.

The conversion uses a trait `ToPack` which is effectively a poor man's
`From` trait. We couldn't use the `From` trait since the "from" and "to"
data structures are both external crates in the eyes of the compiler,
and Rust currently disallows this.

While we are here, remove the "YK_DEBUG_SECTIONS" environment variable
switch, as we are always going to need this information. It's not just a
debugging aid.

We do not yet implement MIR to TIR statement translation. This will be
started in my next PR.

I plan to rename the file `mir_cfg.rs` to something more appropriate
later (say `gen_tir.rs`), but only once my outstanding branches have
been merged.