### PR TITLE
Yk copy good builds

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,9 +2,6 @@
 #
 # Build script for continuous integration.
 
-./x.py clean  # We don't clone afresh to save time and bandwidth.
-git clean -dffx # If upstream removes a submodule, remove the files from disk.
-
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 8)) # 8 GiB
 

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,9 +2,23 @@
 #
 # Build script for continuous integration.
 
+set -e
+
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 8)) # 8 GiB
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v env PATH=/opt/gdb-8.2/bin:${PATH} \
     RUST_BACKTRACE=1 ./x.py test --config .buildbot.toml
+
+# Archive the build and put it in /opt
+TARBALL_TOPDIR=ykrustc-stage2
+TARBALL_NAME=ykrustc-stage2-latest.tar.bz2
+SNAP_DIR=/opt/ykrustc-bin-snapshots
+
+cd build/x86_64-unknown-linux-gnu
+ln -sf stage2 ${TARBALL_TOPDIR}
+git show -s HEAD > ${TARBALL_TOPDIR}/VERSION
+tar hjcvf ${TARBALL_NAME} ${TARBALL_TOPDIR}
+chmod 775 ${TARBALL_NAME}
+mv ${TARBALL_NAME} ${SNAP_DIR} # Overwrites any old archive.


### PR DESCRIPTION
Successful builds are tarred up and placed in /opt/ykrustc-bin-snapshots on the build master.

For now, store at most one archive, but we might change that in the future.

I've tested something very close to this (just without the chmod line in the buildbot script). It *should* work fine 😸 

```
$ ls -al /opt/ykrustc-bin-snapshots/
total 188948
drwxrwxr-x 2 root             buildbot_workers      4096 Apr 18 18:23 .
drwxr-xr-x 8 root             root                  4096 Apr 18 11:32 ..
-rwxrwxr-x 1 buildbot-worker4 buildbot-worker4 193469353 Apr 18 18:23 ykrustc-stage2-057d397c.tar.bz2
$ cd /tmp
$ tar jxf /opt/ykrustc-bin-snapshots/ykrustc-stage2-057d397c.tar.bz2 
$ cd ykrustc-stage2/
$ ls
bin  lib  VERSION
$ cat VERSION 
commit 057d397c982463d374f60e16f9b3863dc660e4f2
Author: Edd Barrett <vext01@gmail.com>
Date:   Thu Apr 18 12:04:20 2019 +0100

    Kill [install].
$ 
```

If you agree with this, then I suppose the next step is to try using the tarball in:
https://github.com/softdevteam/yk/pull/1