### PR TITLE
Perform SSA variable renaming.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
  "rustc_codegen_utils 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_yk_link 0.0.0",
- "ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)",
+ "ykpack 0.1.0",
 ]
 
 [[package]]
@@ -4046,7 +4046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/ykpack#9c5542d9d556ce745f0b21983a009a1297f371e4"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",
@@ -4390,4 +4389,3 @@ dependencies = [
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xz2 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "df8bf41d3030c3577c9458fd6640a05afbf43b150d0b531b16bd77d3f794f27a"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
-"checksum ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)" = "<none>"

--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -118,6 +118,15 @@ impl<Node: Idx> Dominators<Node> {
         self.immediate_dominators[node].unwrap()
     }
 
+    /// Find the children of a node in the dominator tree.
+    pub fn immediately_dominates(&self, node: Node) -> impl Iterator<Item=Node> + '_ {
+        self.immediate_dominators.iter().enumerate()
+            // Index 0 is the root of the dominator tree. It contains a dummy value (itself), which
+            // we must skip or we will end up with infinite loops.
+            .skip(1).filter(move |(_, d)| d.is_some() && d.unwrap() == node)
+            .map(|(i, _)| Node::new(i))
+    }
+
     pub fn dominators(&self, node: Node) -> Iter<'_, Node> {
         assert!(self.is_reachable(node), "node {:?} is not reachable", node);
         Iter {

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -12,7 +12,8 @@ test = false
 [dependencies]
 rustc = { path = "../librustc" }
 rustc_yk_link = { path = "../librustc_yk_link" }
-ykpack = { git = "https://github.com/softdevteam/ykpack" }
+#ykpack = { git = "https://github.com/softdevteam/ykpack" }
+ykpack = { path = "../../../ykpack" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 log = "0.4.5"

--- a/src/librustc_yk_sections/emit_tir.rs
+++ b/src/librustc_yk_sections/emit_tir.rs
@@ -459,7 +459,7 @@ impl<'tcx> ToPack<ykpack::Terminator> for (&ConvCx<'_, 'tcx, '_>, &Terminator<'t
             },
             TerminatorKind::Resume => ykpack::Terminator::Resume,
             TerminatorKind::Abort => ykpack::Terminator::Abort,
-            TerminatorKind::Return => ykpack::Terminator::Return(PRE_SSA_RET_VAR),
+            TerminatorKind::Return => ykpack::Terminator::Return { local: PRE_SSA_RET_VAR },
             TerminatorKind::Unreachable => ykpack::Terminator::Unreachable,
             TerminatorKind::Drop{target: target_bb, unwind: unwind_bb, ..} =>
                 ykpack::Terminator::Drop{

--- a/src/librustc_yk_sections/lib.rs
+++ b/src/librustc_yk_sections/lib.rs
@@ -14,6 +14,5 @@ extern crate rustc_yk_link;
 extern crate rustc_codegen_utils;
 extern crate ykpack;
 extern crate rustc_data_structures;
-#[macro_use] extern crate log;
 
 pub mod emit_tir;

--- a/src/test/yk-tir/simple_phi.rs
+++ b/src/test/yk-tir/simple_phi.rs
@@ -17,11 +17,13 @@ fn main() {
 // ...
 // bb2:
 // ...
+//     Assign(Local(42), Unimplemented)
+// ...
 //     term: SwitchInt { target_bbs: [4, 3] }
 // bb3:
-//     Assign(Local(0), Unimplemented)
+//     Assign(Local(45), Unimplemented)
 //     term: Goto { target_bb: 4 }
 // bb4:
-//     Assign(Local(0), Phi([Local(0), Local(0)]))
+//     Assign(Local(46), Phi([Local(42), Local(45)]))
 // ...
 // [End TIR for main]


### PR DESCRIPTION
Please check carefully. I've been working on this code for so long I feel I can barely see the wood for the trees!

There's a ykpack change associated with this PR. Coming soon.

We perform renaming in-place using a slightly modified version of the
algorithm from the book: Modern Compiler Implementation in Java, 2nd
edition, Andrew Appel.

We experimented with the algorithm from the SSA book by Jeremy Singer
but couldn't get it to work. I suspect there is an error in the
published algorithm, but I may be wrong.

For now this only renames variables for implemented TIR bytecodes, and
not yet in terminators (so return terminators currently always return
variable 0, which will need to be changed).

It may be possible to have the variables numbers start from zero in the
resulting bytecode, but I'm keen to get this in first.

Here are some example CFGs:

![image](https://user-images.githubusercontent.com/604955/56585107-1407b680-65d5-11e9-8c8a-96dce49dd471.png)

---

![image](https://user-images.githubusercontent.com/604955/56585134-21bd3c00-65d5-11e9-9740-13b07144c31e.png)
