### PR TITLE
Build extra tools required for softdevteam/yk.

### DIFF
--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -4,5 +4,9 @@
 codegen-units = 0           # Use many compilation units.
 debug-assertions = true     # Turn on assertions in rustc.
 
+[build]
+extended = true
+tools = ["cargo", "rustfmt"]
+
 [llvm]
 assertions = true           # Turn on assertions in LLVM.


### PR DESCRIPTION
We can't quite use the ykrustc snapshots for testing `yk` because cargo and rustfmt are absent. Let's build 'em.