### PR TITLE
Remove static ssa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,7 @@ dependencies = [
  "rustc_codegen_utils 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_yk_link 0.0.0",
- "ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)",
+ "ykpack 0.1.0 (git+https://github.com/softdevteam/yk)",
 ]
 
 [[package]]
@@ -4045,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/ykpack#9c5542d9d556ce745f0b21983a009a1297f371e4"
+source = "git+https://github.com/softdevteam/yk#0c7016c47bff4b149a2bc1d304cf637f6d64719e"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",
@@ -4389,4 +4389,4 @@ dependencies = [
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xz2 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "df8bf41d3030c3577c9458fd6640a05afbf43b150d0b531b16bd77d3f794f27a"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
-"checksum ykpack 0.1.0 (git+https://github.com/softdevteam/ykpack)" = "<none>"
+"checksum ykpack 0.1.0 (git+https://github.com/softdevteam/yk)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,7 +3062,6 @@ version = "0.0.0"
 name = "rustc_yk_sections"
 version = "0.0.0"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_codegen_utils 0.0.0",
  "rustc_data_structures 0.0.0",

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Edd Barrett <vext01@gmail.com>"]
 name = "rustc_yk_sections"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_yk_sections"

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -15,4 +15,3 @@ rustc_yk_link = { path = "../librustc_yk_link" }
 ykpack = { git = "https://github.com/softdevteam/ykpack" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }
-log = "0.4.5"

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -13,6 +13,6 @@ test = false
 [dependencies]
 rustc = { path = "../librustc" }
 rustc_yk_link = { path = "../librustc_yk_link" }
-ykpack = { git = "https://github.com/softdevteam/ykpack" }
+ykpack = { git = "https://github.com/softdevteam/yk" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/librustc_yk_sections/emit_tir.rs
+++ b/src/librustc_yk_sections/emit_tir.rs
@@ -159,12 +159,12 @@ fn do_generate_tir<'a, 'tcx, 'gcx>(
             // same between builds for the reproducible build tests to pass.
             let mut tir_path = exe_path.clone();
             tir_path.set_extension(TMP_EXT);
-            let mut file = File::create(&tir_path)?;
+            let file = File::create(&tir_path)?;
             (tir_path, Some(file), None)
         },
         TirMode::TextDump(dump_path) => {
             // In text dump mode we just write lines to a file and we don't need an encoder.
-            let mut file = File::create(&dump_path)?;
+            let file = File::create(&dump_path)?;
             (dump_path.clone(), None, Some(file))
         },
     };

--- a/src/librustc_yk_sections/lib.rs
+++ b/src/librustc_yk_sections/lib.rs
@@ -14,6 +14,5 @@ extern crate rustc_yk_link;
 extern crate rustc_codegen_utils;
 extern crate ykpack;
 extern crate rustc_data_structures;
-#[macro_use] extern crate log;
 
 pub mod emit_tir;

--- a/src/test/yk-tir/simple_tir.rs
+++ b/src/test/yk-tir/simple_tir.rs
@@ -22,6 +22,6 @@ fn main() {
 //     Assign(Local(0), Unimplemented)
 //     term: Goto { target_bb: 4 }
 // bb4:
-//     Assign(Local(0), Phi([Local(0), Local(0)]))
+//     Unimplemented
 // ...
 // [End TIR for main]

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,7 +10,7 @@ const WHITELISTED_SOURCES: &[&str] = &[
     // The following are needed for Yorick whilst we use an unreleased revision not on crates.io.
     "\"git+https://github.com/3Hren/msgpack-rust?\
         rev=40b3d480b20961e6eeceb416b32bcd0a3383846a#40b3d480b20961e6eeceb416b32bcd0a3383846a\"",
-    "\"git+https://github.com/softdevteam/ykpack#e0fd6162b9522fd04b6bbb77a232986c4ea5c257\"",
+    "\"git+https://github.com/softdevteam/yk#0c7016c47bff4b149a2bc1d304cf637f6d64719e\"",
 ];
 
 /// Checks for external package sources.


### PR DESCRIPTION
This kills the SSA code in the compiler (and switches the lib to Rust 2018).

I'm just going to check if we can flip this over to using `yk`, so please don't merge just yet.