### PR TITLE
Implement more TIR lowerings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#0c7016c47bff4b149a2bc1d304cf637f6d64719e"
+source = "git+https://github.com/softdevteam/yk#eac9ee05a85f5b7a2158bc5b01b63c8a34f5132f"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",

--- a/src/test/yk-tir/simple_tir.rs
+++ b/src/test/yk-tir/simple_tir.rs
@@ -19,9 +19,8 @@ fn main() {
 // ...
 //     term: SwitchInt { target_bbs: [4, 3] }
 // bb3:
-//     Assign(Local(0), Unimplemented)
+//     Assign(Base(Local(0)), Use(Unimplemented))
 //     term: Goto { target_bb: 4 }
 // bb4:
-//     Unimplemented
 // ...
 // [End TIR for main]

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,7 +10,7 @@ const WHITELISTED_SOURCES: &[&str] = &[
     // The following are needed for Yorick whilst we use an unreleased revision not on crates.io.
     "\"git+https://github.com/3Hren/msgpack-rust?\
         rev=40b3d480b20961e6eeceb416b32bcd0a3383846a#40b3d480b20961e6eeceb416b32bcd0a3383846a\"",
-    "\"git+https://github.com/softdevteam/yk#0c7016c47bff4b149a2bc1d304cf637f6d64719e\"",
+    "\"git+https://github.com/softdevteam/yk#eac9ee05a85f5b7a2158bc5b01b63c8a34f5132f\"",
 ];
 
 /// Checks for external package sources.


### PR DESCRIPTION
This is a whole load more TIR lowerings. The TIR graphs are starting to look more complete, although there's still a lot more to do. I only stopped here because the changes are getting large, and more edits can come in later PRs.

There's one part of this code (which I will point out), which i'm likely to change. It involves a type-parameterised MIR struct, which I think ultimately we will make concrete in TIR. However, I want to see the outcome of this upstream PR first:
https://github.com/rust-lang/rust/pull/60441

There's a ykpack change to accompany this:
https://github.com/softdevteam/yk/pull/3