### PR TITLE
Start lowering to the new TIR format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#8c70d806ee64402e55ab3ccc299bf845b4ec2dd8"
+source = "git+https://github.com/softdevteam/yk#9ad0ec746bd936892413973592a54c49fce055c3"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",

--- a/src/test/yk-tir/simple_tir.rs
+++ b/src/test/yk-tir/simple_tir.rs
@@ -13,6 +13,8 @@ fn main() {
 }
 
 // END RUST SOURCE
-// [Begin TIR for dummy]
+// [Begin TIR for main]
 // ...
-// [End TIR for dummy]
+// $1: t0 = $2: t0
+// ...
+// [End TIR for main]


### PR DESCRIPTION
Here's the beginnings of lowering to the new TIR format from https://github.com/softdevteam/yk/pull/7

Only some assignments are lowered currently.

Note that I ditched the ToPack trait we used before in favour of just using self functions. This means fewer explicit lifetimes have to be specified.

Laurie can sleep easy now this stuff is gone: :P
```
#![allow(unused_variables)]
#![allow(dead_code)]
```
