### PR TITLE
Cater for renamings in ykpack.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#97f82e19c6f1690d0f6153bc76203ed5949709a2"
+source = "git+https://github.com/softdevteam/yk#015c0272ab0bed722c9b55f3df554bf1dcab836a"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",

--- a/src/librustc_yk_sections/emit_tir.rs
+++ b/src/librustc_yk_sections/emit_tir.rs
@@ -96,9 +96,9 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
     }
 
     /// Entry point for the lowering process.
-    fn lower(&mut self) -> ykpack::Tir {
+    fn lower(&mut self) -> ykpack::Body {
         let dps = self.tcx.def_path_str(self.def_id);
-        ykpack::Tir::new(self.lower_def_id(&self.def_id.to_owned()),
+        ykpack::Body::new(self.lower_def_id(&self.def_id.to_owned()),
             dps, self.mir.basic_blocks().iter().map(|b| self.lower_block(b)).collect())
     }
 
@@ -376,7 +376,7 @@ fn do_generate_tir<'a, 'tcx, 'gcx>(
             let pack = ccx.lower();
 
             if let Some(ref mut e) = enc {
-                e.serialise(ykpack::Pack::Tir(pack))?;
+                e.serialise(ykpack::Pack::Body(pack))?;
             } else {
                 write!(textdump_file.as_ref().unwrap(), "{}", pack)?;
             }


### PR DESCRIPTION
See https://github.com/softdevteam/yk/pull/11.

Will need a `Cargo.lock` sync before merge.