### PR TITLE
Store symbol names into TIR call operands.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#015c0272ab0bed722c9b55f3df554bf1dcab836a"
+source = "git+https://github.com/softdevteam/yk#b4b18f5c127cf100129e4f1be469132334ce756b"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",


### PR DESCRIPTION
This is the compiler side change for https://github.com/softdevteam/yk/pull/12

The ykpack change goes in first and then this needs a lock bump.