### PR TITLE
Remove all unwind-related edges and terminators, add stuff needed for guards.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#05df6599ffe54155b7decf38f3a3663a3ac7d322"
+source = "git+https://github.com/softdevteam/yk#3dc8aaec7be58e749ce0171dc58bde55a7489b9f"
 dependencies = [
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",

--- a/src/test/yk-sir/simple_sir.rs
+++ b/src/test/yk-sir/simple_sir.rs
@@ -15,6 +15,6 @@ fn main() {
 // END RUST SOURCE
 // [Begin SIR for main]
 // ...
-// $1: t0 = $2: t0
+// $1: t0 = I32(42)
 // ...
 // [End SIR for main]


### PR DESCRIPTION
This is a companion to https://github.com/softdevteam/yk/pull/17.

The other PR must be merged first.

Some of the new fields in terminators mean that lowering a terminator may now return `Err` for now. Hence the flux.