### PR TITLE
Terminator changes for guards.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#3dc8aaec7be58e749ce0171dc58bde55a7489b9f"
+source = "git+https://github.com/softdevteam/yk#77a73068a745d424f5add8d1fd0a39bba50d2337"
 dependencies = [
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust?rev=40b3d480b20961e6eeceb416b32bcd0a3383846a)",

--- a/src/librustc_yk_sections/emit_sir.rs
+++ b/src/librustc_yk_sections/emit_sir.rs
@@ -178,11 +178,18 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
                     ret_bb: ret_bb,
                 })
             },
-            TerminatorKind::Assert{target: target_bb, ref cond, ..} =>
+            TerminatorKind::Assert{target: target_bb, ref cond, expected, ..} => {
+                let local = match self.lower_operand(cond)? {
+                    ykpack::Operand::Local(l) => l,
+                    // Constant assertions will have been optimised out.
+                    ykpack::Operand::Constant(_) => panic!("constant assertion"),
+                };
                 Ok(ykpack::Terminator::Assert{
-                    cond: self.lower_operand(cond)?,
+                    cond: local,
+                    expected,
                     target_bb: u32::from(target_bb),
-                }),
+                })
+            },
             // We will never see these MIR terminators, as they are not present at code-gen time.
             TerminatorKind::Yield{..} => panic!("Tried to lower a Yield terminator"),
             TerminatorKind::GeneratorDrop => panic!("Tried to lower a GeneratorDrop terminator"),


### PR DESCRIPTION
 * `SwitchInt`: In MIR `SwitchInt` has an implicit "otherwise" case, which I think we should make explicit in SIR: https://github.com/rust-lang/rust/blob/8c6fb028ca887dff9ec2fe0a90398b6d5bf5fb45/src/librustc/mir/mod.rs#L1084-L1096
 * `Assert`: We won't encounter constant asserts, and we need the `expected` field too.

Companion PR: https://github.com/softdevteam/yk/pull/19