### PR TITLE
Partially fix unknown code in SIR traces

### DIFF
--- a/src/librustc_yk_sections/emit_sir.rs
+++ b/src/librustc_yk_sections/emit_sir.rs
@@ -18,8 +18,9 @@ use syntax::ast::{UintTy, IntTy};
 use rustc::hir::def_id::DefId;
 use rustc::mir::{
     Body, Local, BasicBlockData, Statement, StatementKind, Place, PlaceBase, Rvalue, Operand,
-    Terminator, TerminatorKind, Constant, BinOp
+    Terminator, TerminatorKind, Constant, BinOp, NullOp
 };
+use rustc::middle::lang_items::ExchangeMallocFnLangItem;
 use rustc::mir::interpret::{ConstValue, Scalar};
 use rustc::util::nodemap::DefIdSet;
 use std::path::PathBuf;
@@ -57,6 +58,8 @@ struct ConvCx<'a, 'tcx, 'gcx> {
     mir: &'a Body<'tcx>,
     /// The DefId of the above MIR.
     def_id: DefId,
+    /// We keep track of the DefIds that each Body calls so that we can process them later.
+    callee_def_ids: DefIdSet,
 }
 
 impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
@@ -67,6 +70,7 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
             var_map: IndexVec::new(),
             mir,
             def_id,
+            callee_def_ids: DefIdSet::default(),
         }
     }
 
@@ -99,10 +103,11 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
     }
 
     /// Entry point for the lowering process.
-    fn lower(&mut self) -> ykpack::Body {
+    fn lower(mut self) -> (ykpack::Body, DefIdSet) {
         let dps = self.tcx.def_path_str(self.def_id);
-        ykpack::Body::new(self.lower_def_id(&self.def_id.to_owned()),
-            dps, self.mir.basic_blocks().iter().map(|b| self.lower_block(b)).collect())
+        let body = ykpack::Body::new(self.lower_def_id(&self.def_id.to_owned()),
+            dps, self.mir.basic_blocks().iter().map(|b| self.lower_block(b)).collect());
+        (body, self.callee_def_ids)
     }
 
     fn lower_def_id(&mut self, def_id: &DefId) -> ykpack::DefId {
@@ -171,6 +176,7 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
                         true => None,
                         false => Some(self.tcx.symbol_name(inst).as_str().get().to_owned()),
                     };
+                    self.callee_def_ids.insert(*target_def_id);
                     ykpack::CallOperand::Fn(self.lower_def_id(target_def_id), sym_name)
                 } else {
                     // FIXME -- implement other callables.
@@ -247,6 +253,13 @@ impl<'a, 'tcx, 'gcx> ConvCx<'a, 'tcx, 'gcx> {
             Rvalue::BinaryOp(bin_op, o1, o2) =>
                 Ok(ykpack::Rvalue::BinaryOp(self.lower_binary_op(*bin_op), self.lower_operand(o1)?,
                     self.lower_operand(o2)?)),
+            Rvalue::NullaryOp(NullOp::Box, _) => {
+                let def_id = self.tcx.lang_items()
+                    .require(ExchangeMallocFnLangItem)
+                    .expect("can't find DefId for ExchangeMallocFnLangItem");
+                self.callee_def_ids.insert(def_id);
+                Err(()) // FIXME: decide how to lower boxes.
+            },
             _ => Err(()),
         }
     }
@@ -390,28 +403,41 @@ fn do_generate_sir<'a, 'tcx, 'gcx>(
         _ => None,
     };
 
-    // To satisfy the reproducible build tests, the CFG must be written out in a deterministic
-    // order, thus we sort the `DefId`s first.
-    let mut sorted_def_ids: Vec<&DefId> = def_ids.iter().collect();
-    sorted_def_ids.sort();
+    // We use a worklist because as we lower MIR bodies we will discover further DefIds (e.g. call
+    // targets) which in turn will need to be processed. However, to satisfy the reproducible build
+    // tests, we must process the DefIds in a deterministic order. To that end all newly discovered
+    // work must be sorted before it is appended into the work list.
+    let mut work: Vec<DefId> = def_ids.iter().cloned().collect();
+    work.sort();
+    let mut seen =  DefIdSet::default();
+    while !work.is_empty() {
+        let def_id = work.pop().unwrap();
+        if seen.contains(&def_id) {
+            continue;
+        }
 
-    for def_id in sorted_def_ids {
-        if tcx.is_mir_available(*def_id) {
-            let mir = tcx.optimized_mir(*def_id);
-            let mut ccx = ConvCx::new(tcx, *def_id, mir);
-            let pack = ccx.lower();
+        if tcx.is_mir_available(def_id) {
+            let mir = tcx.optimized_mir(def_id);
+            let ccx = ConvCx::new(tcx, def_id, mir);
+            let (pack, mut extra_work) = ccx.lower();
 
             if let Some(ref mut e) = enc {
                 e.serialise(ykpack::Pack::Body(pack))?;
             } else {
                 write!(textdump_file.as_ref().unwrap(), "{}", pack)?;
             }
+
+            let mut extra_work: Vec<DefId> = extra_work.drain().collect();
+            extra_work.sort();
+            work.extend(extra_work);
         }
 
         if let Some(ref mut e) = enc {
             e.serialise(ykpack::Pack::Debug(ykpack::SirDebug::new(
-                lower_def_id(tcx, def_id), tcx.def_path_str(*def_id))))?;
+                lower_def_id(tcx, &def_id), tcx.def_path_str(def_id))))?;
         }
+
+        seen.insert(def_id);
     }
 
     if let Some(e) = enc {


### PR DESCRIPTION
This PR fixes some of the unknown entries in our (currently skipped) yktrace test.

The fix comes in two related, but separate, parts. See the commit messages.

Before these changes, the SIR trace looked like this:
```
[<unknown>] crate=9716225740442656270, index=51, bb=1
[<unknown>] crate=5705253629357860373, index=81, bb=0
[<unknown>] crate=5705253629357860373, index=35, bb=0
[<unknown>] crate=5705253629357860373, index=35, bb=1
[<unknown>] crate=5705253629357860373, index=35, bb=8
[<unknown>] crate=9716225740442656270, index=51, bb=2
[<unknown>] crate=9716225740442656270, index=121, bb=8
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=2
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=3
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=0
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=2
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=5
[<unknown>] crate=9716225740442656270, index=117, bb=0
[<unknown>] crate=9716225740442656270, index=50, bb=0
```

Notice how all of the locations we know about are in the same crate (the one being compiled). This is because only made SIR debug entries for the crate being compiled and not for places referenced by the code which reside outside the current crate (i.e. external call targets).

And after our changes, we have:
```
[yktrace::swt::start_tracing] crate=11903411042698849244, index=67, bb=1
[std::boxed::Box::<T>::new] crate=10739070413513156184, index=81, bb=0
[<unknown>] crate=10739070413513156184, index=35, bb=0
[<unknown>] crate=10739070413513156184, index=35, bb=1
[<unknown>] crate=10739070413513156184, index=35, bb=8
[yktrace::swt::start_tracing] crate=11903411042698849244, index=67, bb=2
[yktrace::start_tracing] crate=11903411042698849244, index=120, bb=8
[tests::interp_simple_trace] crate=11324160893246211593, index=43, bb=2
[tests::interp_simple_trace] crate=11324160893246211593, index=43, bb=3
[tests::interp_simple_trace] crate=11324160893246211593, index=43, bb=4    
[tests::work] crate=11324160893246211593, index=39, bb=0
[tests::work] crate=11324160893246211593, index=39, bb=1
[tests::work] crate=11324160893246211593, index=39, bb=3
[tests::work] crate=11324160893246211593, index=39, bb=4
[tests::work] crate=11324160893246211593, index=39, bb=1         
[tests::work] crate=11324160893246211593, index=39, bb=3
[tests::work] crate=11324160893246211593, index=39, bb=4
[tests::work] crate=11324160893246211593, index=39, bb=1
[tests::work] crate=11324160893246211593, index=39, bb=3
[tests::work] crate=11324160893246211593, index=39, bb=4
[tests::work] crate=11324160893246211593, index=39, bb=1
[tests::work] crate=11324160893246211593, index=39, bb=3
[tests::work] crate=11324160893246211593, index=39, bb=4
[tests::work] crate=11324160893246211593, index=39, bb=1
[tests::work] crate=11324160893246211593, index=39, bb=3
[tests::work] crate=11324160893246211593, index=39, bb=4
[tests::work] crate=11324160893246211593, index=39, bb=1
[tests::work] crate=11324160893246211593, index=39, bb=2
[tests::interp_simple_trace] crate=11324160893246211593, index=43, bb=5
[yktrace::ThreadTracer::stop_tracing] crate=11903411042698849244, index=116, bb=0
[<unknown>] crate=11903411042698849244, index=66, bb=0
```

Notice many of the unknowns are now resolved.

As you can see the something inside `Box::new` was not found in the SIR. `Box::new` is implemented like this:
```
    pub fn new(x: T) -> Box<T> {                                                    
        box x                                                                       
    }
```

I've been unable to find the implementation of `box` (yet), but I bet it's invocation leads to a special kind of call. Currently we only recognise the simplest of calls (only `TerminatorKind::Call` is supported, but there are other kinds, e.g. calls to closures). My next PR will address this.

Big picture: In a later PR we will need to trim the trace. As you can see we catch parts of the start/stop tracing functionality at the beginning/end of the trace. Although we could mark those function `no_trace`, we'd still see the boxing (called from within those functions) in the trace. Since adding `no_trace` to boxing would we unwise, I reckon trimming is the right thing to do.