### PR TITLE
Remove custom DefId collection in favour of tcx.collect_and_partition_mono_items().

### DIFF
--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -62,7 +62,6 @@ use rustc::middle::cstore::{EncodedMetadata, MetadataLoader};
 use rustc::session::Session;
 use rustc::session::config::{OutputFilenames, OutputType, PrintRequest, OptLevel};
 use rustc::ty::{self, TyCtxt};
-use rustc::util::nodemap::DefIdSet;
 use rustc::util::common::ErrorReported;
 use rustc_codegen_ssa::ModuleCodegen;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
@@ -292,10 +291,9 @@ impl CodegenBackend for LlvmCodegenBackend {
         metadata: EncodedMetadata,
         need_metadata_module: bool,
         rx: mpsc::Receiver<Box<dyn Any + Send>>
-    ) -> (Box<dyn Any>, Arc<DefIdSet>) {
-        let (codegen, def_ids) = rustc_codegen_ssa::base::codegen_crate(
-            LlvmCodegenBackend(()), tcx, metadata, need_metadata_module, rx);
-        (box codegen, def_ids)
+    ) -> Box<dyn Any> {
+        box rustc_codegen_ssa::base::codegen_crate(
+            LlvmCodegenBackend(()), tcx, metadata, need_metadata_module, rx)
     }
 
     fn join_codegen_and_link(

--- a/src/librustc_codegen_utils/codegen_backend.rs
+++ b/src/librustc_codegen_utils/codegen_backend.rs
@@ -10,7 +10,7 @@
 #![feature(box_syntax)]
 
 use std::any::Any;
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 
 use syntax::symbol::Symbol;
 use rustc::session::Session;
@@ -20,7 +20,6 @@ use rustc::ty::TyCtxt;
 use rustc::ty::query::Providers;
 use rustc::middle::cstore::{EncodedMetadata, MetadataLoader};
 use rustc::dep_graph::DepGraph;
-use rustc::util::nodemap::DefIdSet;
 
 pub use rustc_data_structures::sync::MetadataRef;
 
@@ -41,7 +40,7 @@ pub trait CodegenBackend {
         metadata: EncodedMetadata,
         need_metadata_module: bool,
         rx: mpsc::Receiver<Box<dyn Any + Send>>
-    ) -> (Box<dyn Any>, Arc<DefIdSet>);
+    ) -> Box<dyn Any>;
 
     /// This is called on the returned `Box<dyn Any>` from `codegen_backend`
     ///

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1083,7 +1083,7 @@ pub fn start_codegen<'tcx>(
     });
 
     tcx.sess.profiler(|p| p.start_activity("codegen crate"));
-    let (codegen, def_ids) = time(tcx.sess, "codegen", move || {
+    let codegen = time(tcx.sess, "codegen", move || {
         codegen_backend.codegen_crate(tcx, metadata, need_metadata_module, rx)
     });
     tcx.sess.profiler(|p| p.end_activity("codegen crate"));
@@ -1102,6 +1102,7 @@ pub fn start_codegen<'tcx>(
 
     // Output Yorick debug sections into binary targets.
     if tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
+        let (def_ids, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
         let sir_mode = if tcx.sess.opts.output_types.contains_key(&OutputType::YkSir) {
             // The user passed "--emit yk-sir" so we will output textual SIR and stop.
             SirMode::TextDump(outputs.path(OutputType::YkSir))

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -17,7 +17,6 @@ use rustc::ty::TyCtxt;
 use rustc::ty::query::Providers;
 use rustc::middle::cstore::{EncodedMetadata, MetadataLoader};
 use rustc::dep_graph::DepGraph;
-use rustc::util::nodemap::DefIdSet;
 use rustc::util::common::ErrorReported;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_data_structures::sync::MetadataRef;
@@ -65,10 +64,10 @@ impl CodegenBackend for TheBackend {
         _metadata: EncodedMetadata,
         _need_metadata_module: bool,
         _rx: mpsc::Receiver<Box<Any + Send>>
-    ) -> (Box<Any>, Arc<DefIdSet>) {
+    ) -> Box<Any> {
         use rustc::hir::def_id::LOCAL_CRATE;
 
-        (Box::new(tcx.crate_name(LOCAL_CRATE) as Symbol), Arc::new(DefIdSet::default()))
+        Box::new(tcx.crate_name(LOCAL_CRATE) as Symbol)
     }
 
     fn join_codegen_and_link(


### PR DESCRIPTION
This draft implements @bjorn3's suggestion:
> you can use tcx.collect_and_partition_mono_items to get all functions and statics which need codegen instead of doing it manually. Your way may be a bit faster though.

In my rough benchmarking of a small program, we didn't slow down any measurable amount.  I'm going to `bors try` this first to see if we slowed down the compilation process too much.

bors try