### PR TITLE
Discover additional DefIds by looking in the def_path_table.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -11,7 +11,7 @@ TARBALL_NAME=ykrustc-stage2-latest.tar.bz2
 SNAP_DIR=/opt/ykrustc-bin-snapshots
 
 # Ensure the build fails if it uses excessive amounts of memory.
-ulimit -d $((1024 * 1024 * 8)) # 8 GiB
+ulimit -d $((1024 * 1024 * 12)) # 12 GiB
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -215,6 +215,7 @@ pub trait CrateStore {
                                  tcx: TyCtxt<'a, 'tcx, 'tcx>)
                                  -> EncodedMetadata;
     fn metadata_encoding_version(&self) -> &[u8];
+    fn def_path_table_lens(&self) -> Vec<usize>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -64,7 +64,7 @@ use std::hash::{Hash, Hasher};
 use std::fmt;
 use std::mem;
 use std::ops::{Deref, Bound};
-use std::iter;
+use std::iter::{self, FromIterator};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::marker::PhantomData;
@@ -1460,6 +1460,24 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     pub fn metadata_encoding_version(self) -> Vec<u8> {
         self.cstore.metadata_encoding_version().to_vec()
+    }
+
+    pub fn metadata_mir_defids(&self) -> DefIdSet {
+        let mut res = Vec::new();
+        let tbl_lens = self.cstore.def_path_table_lens();
+
+        for (cnum, ln) in tbl_lens.iter().enumerate() {
+            for idx in 0..*ln {
+                let def_id = DefId {
+                    krate: CrateNum::from_usize(cnum),
+                    index: DefIndex::from_usize(idx)
+                };
+                if self.is_mir_available(def_id) {
+                    res.push(def_id);
+                }
+            }
+        }
+        DefIdSet::from_iter(res)
     }
 
     // Note that this is *untracked* and should only be used within the query

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -64,7 +64,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::iter;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::mem;
@@ -1102,7 +1102,9 @@ pub fn start_codegen<'tcx>(
 
     // Output Yorick debug sections into binary targets.
     if tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
-        let (def_ids, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
+        let mut def_ids = tcx.metadata_mir_defids();
+        def_ids.extend(tcx.collect_and_partition_mono_items(LOCAL_CRATE).0.iter());
+
         let sir_mode = if tcx.sess.opts.output_types.contains_key(&OutputType::YkSir) {
             // The user passed "--emit yk-sir" so we will output textual SIR and stop.
             SirMode::TextDump(outputs.path(OutputType::YkSir))

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -561,4 +561,16 @@ impl CrateStore for cstore::CStore {
     {
         schema::METADATA_HEADER
     }
+
+    /// Returns a vector of definition path table lengths for all crates. The vector indices
+    /// correspond with crate numbers. Index 0 (the local crate) always reports length 0.
+    fn def_path_table_lens(&self) -> Vec<usize> {
+        let mut res = vec![0];
+        self.iter_crate_data(|cnum, md| {
+            // We are assuming the crates come out in order.
+            debug_assert!(cnum.as_usize() == res.len());
+            res.push(md.def_path_table.size());
+        });
+        res
+    }
 }

--- a/src/test/debuginfo/empty-string.rs
+++ b/src/test/debuginfo/empty-string.rs
@@ -1,5 +1,6 @@
 // ignore-windows failing on win32 bot
 // ignore-android: FIXME(#10381)
+// ignore-test FIXME swt_ignore
 // compile-flags:-g
 // min-gdb-version: 7.7
 // min-lldb-version: 310

--- a/src/test/debuginfo/generator-locals.rs
+++ b/src/test/debuginfo/generator-locals.rs
@@ -1,4 +1,6 @@
 // min-lldb-version: 310
+// ignore-test FIXME swt_ignore
+// ^-- See https://github.com/rust-lang/rust/pull/63742
 
 // compile-flags:-g
 


### PR DESCRIPTION
The "definition path table" is a mapping from DefIds to definition
paths. There's an entry for every item than appears in the compiler's
metadata, thus making it an excellent discovery tool for our serialiser
code to find DefIds in dependent crates (if you run with `-Z
always-encode-mir`)!

We also switch to using tcx.mir_keys() for finding the DefIds in the
current crate. Previously we used tcx.collect_and_partition_mono_items()
which may miss some stuff.

A future change will remove the work list used in the serialised, as this
code supersedes it. That will be a fairly large change, so saving it for
another PR.

Another future change will enable `-Z always-encode-mir` by default for
ykrustc.