### PR TITLE
Insert yorick labels at the start of each block and insert compile-time tracer switch.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -5,9 +5,11 @@
 set -e
 
 export PATH=PATH=/opt/gdb-8.2/bin:${PATH}
-# This disables encoding SIR into the compiler binaries. We do this because
-# encoding SIR is slow and we don't SIR in the compiler binaries anyway.
-export YK_NO_SIR=1
+# For now we only test the software tracer in CI. We use `sw-rustc` below so
+# that the standard library is software-tracing ready, but the compiler
+# binaries themselves do not contain SIR (making SIR really slows down testing,
+# and it isn't necessary for the compiler itself anyway).
+export YK_TRACER=sw-rustc
 
 TARBALL_TOPDIR=`pwd`/build/ykrustc-stage2-latest
 TARBALL_NAME=ykrustc-stage2-latest.tar.bz2

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -5,11 +5,11 @@
 set -e
 
 export PATH=PATH=/opt/gdb-8.2/bin:${PATH}
-# For now we only test the software tracer in CI. We use `sw-rustc` below so
+# For now we only test the software tracer in CI. We use `sw-nosir` below so
 # that the standard library is software-tracing ready, but the compiler
 # binaries themselves do not contain SIR (making SIR really slows down testing,
 # and it isn't necessary for the compiler itself anyway).
-export YK_TRACER=sw-rustc
+export YK_TRACER=sw-nosir
 
 TARBALL_TOPDIR=`pwd`/build/ykrustc-stage2-latest
 TARBALL_NAME=ykrustc-stage2-latest.tar.bz2

--- a/src/libcore/yk_swt.rs
+++ b/src/libcore/yk_swt.rs
@@ -41,7 +41,7 @@ impl SirLoc {
 /// This is implemented in C so that: the `yk_swt_calls` MIR pass doesn't see inside.
 #[allow(dead_code)] // Used only indirectly in a MIR pass.
 #[cfg_attr(not(stage0), lang="yk_swt_rec_loc")]
-#[cfg_attr(not(stage0), no_trace)]
+#[cfg_attr(not(stage0), no_sw_trace)]
 #[cfg(not(test))]
 fn yk_swt_rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
     extern "C" { fn yk_swt_rec_loc_impl(crate_hash: u64, def_idx: u32, bb_idx: u32); }
@@ -49,7 +49,7 @@ fn yk_swt_rec_loc(crate_hash: u64, def_idx: u32, bb_idx: u32) {
 }
 
 /// Start software tracing on the current thread. The current thread must not already be tracing.
-#[cfg_attr(not(stage0), no_trace)]
+#[cfg_attr(not(stage0), no_sw_trace)]
 pub fn start_tracing() {
     extern "C" { fn yk_swt_start_tracing_impl(); }
     unsafe { yk_swt_start_tracing_impl(); }
@@ -58,7 +58,7 @@ pub fn start_tracing() {
 /// Stop software tracing and on success return a tuple containing a pointer to the raw trace
 /// buffer, and the number of items inside. Returns `None` if the trace was invalidated, or if an
 /// error occurred. The current thread must already be tracing.
-#[cfg_attr(not(stage0), no_trace)]
+#[cfg_attr(not(stage0), no_sw_trace)]
 pub fn stop_tracing() -> Option<(*mut SirLoc, usize)> {
     let len: usize = 0;
 
@@ -73,7 +73,7 @@ pub fn stop_tracing() -> Option<(*mut SirLoc, usize)> {
 }
 
 /// Invalidate the software trace, if one is being collected.
-#[cfg_attr(not(stage0), no_trace)]
+#[cfg_attr(not(stage0), no_sw_trace)]
 pub fn invalidate_trace() {
     extern "C" { fn yk_swt_invalidate_trace_impl(); }
     unsafe { yk_swt_invalidate_trace_impl(); }

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -91,6 +91,7 @@ impl BackendTypes for CodegenCx<'ll, 'tcx> {
     type Funclet = Funclet<'ll>;
 
     type DIScope = &'ll llvm::debuginfo::DIScope;
+    type DISubprogram = &'ll llvm::debuginfo::DISubprogram;
 }
 
 impl CodegenCx<'ll, 'tcx> {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -99,6 +99,10 @@ impl<'a, 'tcx> CrateDebugContext<'a, 'tcx> {
             composite_types_completed: Default::default(),
         }
     }
+
+    pub fn get_builder(&self) -> &DIBuilder<'a> {
+        &self.builder
+    }
 }
 
 /// Creates any deferred debug metadata nodes
@@ -549,5 +553,9 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
              byte_offset_of_var_in_env as i64,
              llvm::LLVMRustDIBuilderCreateOpDeref()]
         }
+    }
+
+    fn has_debug(&self) -> bool {
+        self.dbg_cx.is_some()
     }
 }

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -815,6 +815,7 @@ extern "C" {
 
     // Operations on instructions
     pub fn LLVMGetFirstBasicBlock(Fn: &Value) -> &BasicBlock;
+    pub fn LLVMGetFirstInstruction(BB: &BasicBlock) -> Option<&Value>;
 
     // Operations on call sites
     pub fn LLVMSetInstructionCallConv(Instr: &Value, CC: c_uint);
@@ -836,6 +837,7 @@ extern "C" {
 
     // Instruction builders
     pub fn LLVMCreateBuilderInContext(C: &'a Context) -> &'a mut Builder<'a>;
+    pub fn LLVMPositionBuilderBefore(Builder: &Builder<'a>, Instr: &Value);
     pub fn LLVMPositionBuilderAtEnd(Builder: &Builder<'a>, Block: &'a BasicBlock);
     pub fn LLVMGetInsertBlock(Builder: &Builder<'a>) -> &'a BasicBlock;
     pub fn LLVMDisposeBuilder(Builder: &'a mut Builder<'a>);
@@ -1653,6 +1655,14 @@ extern "C" {
                                                 -> &'a Value;
     pub fn LLVMRustDIBuilderCreateOpDeref() -> i64;
     pub fn LLVMRustDIBuilderCreateOpPlusUconst() -> i64;
+
+    pub fn LLVMRustAddYkBlockLabel(Builder: &Builder<'a>, DIBuilder: &DIBuilder<'a>,
+                                   SP: &DISubprogram, InsertBefore: &Value,
+                                   Name: *const c_char);
+
+    pub fn LLVMRustAddYkBlockLabelAtEnd(Builder: &Builder<'a>, DIBuilder: &DIBuilder<'a>,
+                                   SP: &DISubprogram, InsertAfter: &BasicBlock,
+                                   Name: *const c_char);
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTypeToString(Type: &Type, s: &RustString);

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -11,6 +11,7 @@ use crate::common::{self, IntPredicate};
 use crate::meth;
 
 use std::ffi::CString;
+use std::env;
 
 use crate::traits::*;
 
@@ -803,7 +804,16 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         debug!("codegen_block({:?}={:?})", bb, data);
 
-        if bx.cx().has_debug() {
+        let tracer = match env::var("YK_TRACER") {
+            Ok(val) => match val.as_str() {
+                "hw" => true,
+                "sw" | "sw-rustc" => false,
+                unknown => panic!("Invalid YK_TRACER environment: {}", unknown),
+            }
+            Err(_) => false
+        };
+
+        if tracer && bx.cx().has_debug() {
             let did = self.instance.def.def_id();
             let lbl_name = CString::new(format!("__YK_BLK_{}_{}_{}", did.krate.as_u32(),
                                         did.index.as_u32(), bb.index())).unwrap();

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -807,7 +807,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let tracer = match env::var("YK_TRACER") {
             Ok(val) => match val.as_str() {
                 "hw" => true,
-                "sw" | "sw-rustc" => false,
+                "sw" | "sw-nosir" => false,
                 unknown => panic!("Invalid YK_TRACER environment: {}", unknown),
             }
             Err(_) => false

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -107,6 +107,10 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         bx.set_source_location(&mut self.debug_context, scope, span);
     }
 
+    pub fn fn_metadata(&self, span: Span) -> &Bx::DIScope {
+        &self.debug_context.get_ref(span).fn_metadata
+    }
+
     pub fn debug_loc(&self, source_info: mir::SourceInfo) -> (Option<Bx::DIScope>, Span) {
         // Bail out if debug info emission is not enabled.
         match self.debug_context {

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -18,6 +18,7 @@ pub trait BackendTypes {
     type Funclet;
 
     type DIScope: Copy;
+    type DISubprogram: Copy;
 }
 
 pub trait Backend<'tcx>:

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -14,6 +14,7 @@ use rustc::ty::layout::{Align, Size, HasParamEnv};
 use rustc_target::spec::{HasTargetSpec};
 use std::ops::Range;
 use std::iter::TrustedLen;
+use std::ffi::CString;
 
 #[derive(Copy, Clone)]
 pub enum OverflowOp {
@@ -40,6 +41,10 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn cx(&self) -> &Self::CodegenCx;
     fn llbb(&self) -> Self::BasicBlock;
 
+    fn first_instruction(&mut self, llbb: Self::BasicBlock) -> Option<Self::Value>;
+    fn add_yk_block_label(&mut self, di_sp: Self::DIScope, lbl_name: CString);
+    fn add_yk_block_label_at_end(&mut self, di_sp: Self::DIScope, lbl_name: CString);
+    fn position_before(&mut self, instr: Self::Value);
     fn position_at_end(&mut self, llbb: Self::BasicBlock);
     fn ret_void(&mut self);
     fn ret(&mut self, v: Self::Value);

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -37,6 +37,7 @@ pub trait DebugInfoMethods<'tcx>: BackendTypes {
     ) -> Self::DIScope;
     fn debuginfo_finalize(&self);
     fn debuginfo_upvar_ops_sequence(&self, byte_offset_of_var_in_env: u64) -> [i64; 4];
+    fn has_debug(&self) -> bool;
 }
 
 pub trait DebugInfoBuilderMethods<'tcx>: BackendTypes {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1109,10 +1109,10 @@ pub fn start_codegen<'tcx>(
         Ok(val) => {
             match val.as_str() {
                 "hw" | "sw" => true,
-                // We use `sw-rustc` when building the compiler itself for software tracing.
+                // We use `sw-nosir` when building the compiler itself for software tracing.
                 // There's no need to encode SIR into compiler tools and it would make the
                 // build/test cycle very slow.
-                "sw-rustc" => false,
+                "sw-nosir" => false,
                 unknown => panic!("Invalid YK_TRACER environment: {}", unknown)
             }
         },

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1102,11 +1102,24 @@ pub fn start_codegen<'tcx>(
     }
 
     // Output Yorick debug sections into binary targets if necessary.
-    let no_sir = match env::var("YK_NO_SIR") {
-        Ok(val) => val == "1",
+    // FIXME: YK_TRACER should eventually be a proper compiler flag and there should be a function
+    // for asking which tracer is being used. Then all places reading YK_TRACER can use that
+    // instead.
+    let enc_sir = match env::var("YK_TRACER") {
+        Ok(val) => {
+            match val.as_str() {
+                "hw" | "sw" => true,
+                // We use `sw-rustc` when building the compiler itself for software tracing.
+                // There's no need to encode SIR into compiler tools and it would make the
+                // build/test cycle very slow.
+                "sw-rustc" => false,
+                unknown => panic!("Invalid YK_TRACER environment: {}", unknown)
+            }
+        },
         Err(_) => false,
     };
-    if !no_sir && tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
+
+    if enc_sir && tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
         let def_ids = tcx.collect_and_partition_mono_items(LOCAL_CRATE).0;
         let mut def_ids = (*def_ids).clone();
         for cnum in tcx.crates() {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -24,6 +24,7 @@ use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_serialize::{Encodable, Encoder, SpecializedEncoder, opaque};
 
+use std::env;
 use std::hash::Hash;
 use std::path::Path;
 use rustc_data_structures::sync::Lrc;
@@ -62,6 +63,20 @@ macro_rules! encoder_methods {
         $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
             self.opaque.$name(value)
         })*
+    }
+}
+
+/// A check to see if we are using a Yorick tracer. Used to decide whether we need to encode MIR
+/// for all items.
+fn building_with_yk_tracer() -> bool {
+    match env::var("YK_TRACER") {
+        Ok(val) => {
+            match val.as_str() {
+                "hw" | "sw" | "sw-rustc" => true,
+                unknown => panic!("Bad YK_TRACER environment: {}", unknown),
+            }
+        },
+        Err(_) => false,
     }
 }
 
@@ -979,7 +994,8 @@ impl EncodeContext<'_, 'tcx> {
                                         tcx.codegen_fn_attrs(def_id).requests_inline()) &&
                                         !self.metadata_output_only();
                     let is_const_fn = sig.header.constness == hir::Constness::Const;
-                    let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
+                    let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir
+                        || building_with_yk_tracer();
                     needs_inline || is_const_fn || always_encode_mir
                 },
                 hir::ImplItemKind::Existential(..) |
@@ -1297,7 +1313,8 @@ impl EncodeContext<'_, 'tcx> {
                         (generics.requires_monomorphization(tcx) ||
                          tcx.codegen_fn_attrs(def_id).requests_inline()) &&
                             !self.metadata_output_only();
-                    let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
+                    let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir
+                        || building_with_yk_tracer();
                     if needs_inline
                         || header.constness == hir::Constness::Const
                         || always_encode_mir

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -72,7 +72,7 @@ fn building_with_yk_tracer() -> bool {
     match env::var("YK_TRACER") {
         Ok(val) => {
             match val.as_str() {
-                "hw" | "sw" | "sw-rustc" => true,
+                "hw" | "sw" | "sw-nosir" => true,
                 unknown => panic!("Bad YK_TRACER environment: {}", unknown),
             }
         },

--- a/src/librustc_mir/transform/add_yk_swt_calls.rs
+++ b/src/librustc_mir/transform/add_yk_swt_calls.rs
@@ -138,7 +138,7 @@ impl MirPass for AddYkSWTCalls {
 /// Given a `MirSource`, decides if it is possible for us to trace (and thus whether we should
 /// transform) the MIR. Returns `true` if we cannot trace, otherwise `false`.
 fn is_untraceable(tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource<'_>) -> bool {
-    // Never annotate anything annotated with the `#[no_trace]` attribute. This is used on tests
+    // Never annotate anything annotated with the `#[no_sw_trace]` attribute. This is used on tests
     // where our pass would interfere and on the trace recorder to prevent infinite
     // recursion.
     //
@@ -146,7 +146,7 @@ fn is_untraceable(tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource<'_>) -> bool {
     // binary-level function epilogues and prologues, often using in-line assembler. We can't
     // automatically insert our calls into such code without breaking stuff.
     for attr in tcx.get_attrs(src.def_id()).iter() {
-        if attr.check_name(sym::no_trace) {
+        if attr.check_name(sym::no_sw_trace) {
             return true;
         }
         if attr.check_name(sym::naked) {
@@ -154,9 +154,10 @@ fn is_untraceable(tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource<'_>) -> bool {
        }
     }
 
-    // Similar to `#[no_trace]`, don't transform anything inside a crate marked `#![no_trace]`.
+    // Similar to `#[no_sw_trace]`, don't transform anything inside a crate marked
+    // `#![no_sw_trace]`.
     for attr in tcx.hir().krate_attrs() {
-        if attr.check_name(sym::no_trace) {
+        if attr.check_name(sym::no_sw_trace) {
             return true;
         }
     }

--- a/src/librustc_mir/transform/add_yk_swt_calls.rs
+++ b/src/librustc_mir/transform/add_yk_swt_calls.rs
@@ -52,7 +52,7 @@ impl MirPass for AddYkSWTCalls {
         match env::var("YK_TRACER") {
             Ok(val) => {
                 match val.as_str() {
-                    "sw" | "sw-rustc" => (),
+                    "sw" | "sw-nosir" => (),
                     "hw" => return,
                     unknown => panic!("Invalid YK_TRACER environment: {}", unknown),
                 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1000,7 +1000,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     (sym::automatically_derived, Normal, template!(Word), Ungated),
     (sym::no_mangle, Whitelisted, template!(Word), Ungated),
     // Don't trace this. Disables the `AddYkSWTCalls` MIR transform.
-    (sym::no_trace, Whitelisted, template!(Word), Ungated),
+    (sym::no_sw_trace, Whitelisted, template!(Word), Ungated),
     (sym::no_link, Normal, template!(Word), Ungated),
     (sym::derive, Normal, template!(List: "Trait1, Trait2, ..."), Ungated),
     (

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -406,7 +406,7 @@ symbols! {
         no_default_passes,
         no_implicit_prelude,
         no_inline,
-        no_trace,
+        no_sw_trace,
         no_link,
         no_main,
         no_mangle,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -5,6 +5,7 @@
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
@@ -952,6 +953,27 @@ extern "C" int64_t LLVMRustDIBuilderCreateOpDeref() {
 
 extern "C" int64_t LLVMRustDIBuilderCreateOpPlusUconst() {
   return dwarf::DW_OP_plus_uconst;
+}
+
+extern "C" bool LLVMRustAddYkBlockLabel(LLVMBuilderRef Builder,
+                                        LLVMRustDIBuilderRef DBuilder,
+                                        DISubprogram *SP, Instruction *Instr,
+                                        char *Name) {
+    // FIXME Add useful location info?
+    auto Loc = DebugLoc::get(0, 0, SP);
+    DILabel *label = DBuilder->createLabel(SP, Name, SP->getFile(), 0, true);
+    DBuilder->insertLabel(label, Loc, Instr);
+    return true;
+}
+
+extern "C" bool LLVMRustAddYkBlockLabelAtEnd(LLVMBuilderRef Builder,
+                                             LLVMRustDIBuilderRef DBuilder,
+                                             DISubprogram *SP,
+                                             BasicBlock *Block, char *Name) {
+    auto Loc = DebugLoc::get(0, 0, SP);
+    DILabel *label = DBuilder->createLabel(SP, Name, SP->getFile(), 0, true);
+    DBuilder->insertLabel(label, Loc, Block);
+    return true;
 }
 
 extern "C" void LLVMRustWriteTypeToString(LLVMTypeRef Ty, RustStringRef Str) {

--- a/src/test/codegen/issue-34947-pow-i32.rs
+++ b/src/test/codegen/issue-34947-pow-i32.rs
@@ -1,7 +1,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 // CHECK-LABEL: @issue_34947
 #[no_mangle]

--- a/src/test/codegen/issue-45222.rs
+++ b/src/test/codegen/issue-45222.rs
@@ -1,7 +1,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 // verify that LLVM recognizes a loop involving 0..=n and will const-fold it.
 

--- a/src/test/codegen/issue-45466.rs
+++ b/src/test/codegen/issue-45466.rs
@@ -1,7 +1,7 @@
 // compile-flags: -O
 
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 // CHECK-LABEL: @memzero
 // CHECK-NOT: store

--- a/src/test/codegen/match-optimizes-away.rs
+++ b/src/test/codegen/match-optimizes-away.rs
@@ -2,7 +2,7 @@
 // no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]
-#![no_trace]
+#![no_sw_trace]
 
 pub enum Three { A, B, C }
 

--- a/src/test/codegen/match.rs
+++ b/src/test/codegen/match.rs
@@ -1,7 +1,7 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 pub enum E {
     A,

--- a/src/test/codegen/nounwind-extern.rs
+++ b/src/test/codegen/nounwind-extern.rs
@@ -1,7 +1,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 // CHECK: Function Attrs: norecurse nounwind
 pub extern fn foo() {}

--- a/src/test/codegen/scalar-pair-bool.rs
+++ b/src/test/codegen/scalar-pair-bool.rs
@@ -1,7 +1,7 @@
 // compile-flags: -O
 
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 // CHECK: define { i8, i8 } @pair_bool_bool(i1 zeroext %pair.0, i1 zeroext %pair.1)
 #[no_mangle]

--- a/src/test/codegen/slice-position-bounds-check.rs
+++ b/src/test/codegen/slice-position-bounds-check.rs
@@ -1,7 +1,7 @@
 // no-system-llvm
 // compile-flags: -O -C panic=abort
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 fn search<T: Ord + Eq>(arr: &mut [T], a: &T) -> Result<usize, ()> {
     match arr.iter().position(|x| x == a) {

--- a/src/test/debuginfo/associated-types.rs
+++ b/src/test/debuginfo/associated-types.rs
@@ -85,7 +85,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 trait TraitWithAssocType {
     type Type;

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -116,7 +116,7 @@
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let bool_val: bool = true;

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -37,7 +37,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 enum ABC { TheA, TheB, TheC }
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -35,7 +35,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -66,7 +66,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct SomeStruct {
     x: isize,

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -40,7 +40,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let stack_val: (i16, f32) = (-14, -19f32);

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -119,7 +119,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let bool_box: Box<bool> = box true;

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -27,7 +27,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let a = box 1;

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -33,7 +33,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct StructWithSomePadding {
     x: i16,

--- a/src/test/debuginfo/c-style-enum-in-composite.rs
+++ b/src/test/debuginfo/c-style-enum-in-composite.rs
@@ -69,7 +69,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::AnEnum::{OneHundred, OneThousand, OneMillion};
 use self::AnotherEnum::{MountainView, Toronto, Vienna};

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -361,7 +361,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -288,7 +288,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/evec-in-struct.rs
+++ b/src/test/debuginfo/evec-in-struct.rs
@@ -54,7 +54,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct NoPadding1 {
     x: [u32; 3],

--- a/src/test/debuginfo/extern-c-fn.rs
+++ b/src/test/debuginfo/extern-c-fn.rs
@@ -41,7 +41,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 
 #[no_mangle]

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -28,7 +28,7 @@
 // gdbr-check:$5 = gdb_pretty_struct_and_enums::CStyleEnum::CStyleEnumVar3
 
 #![allow(dead_code, unused_variables)]
-#![no_trace]
+#![no_sw_trace]
 
 struct RegularStruct {
     the_first_field: isize,

--- a/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -64,7 +64,7 @@
 #![allow(dead_code)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 // This test case makes sure that we get correct type descriptions for the enum
 // discriminant of different instantiations of the same generic enum type where,

--- a/src/test/debuginfo/generic-function.rs
+++ b/src/test/debuginfo/generic-function.rs
@@ -76,7 +76,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 #[derive(Clone)]
 struct Struct {

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -25,7 +25,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/generic-struct.rs
+++ b/src/test/debuginfo/generic-struct.rs
@@ -44,7 +44,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct AGenericStruct<TKey, TValue> {
     key: TKey,

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -44,7 +44,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/include_string.rs
+++ b/src/test/debuginfo/include_string.rs
@@ -30,7 +30,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 // This test case makes sure that debug info does not ICE when include_str is
 // used multiple times (see issue #11322).

--- a/src/test/debuginfo/issue-12886.rs
+++ b/src/test/debuginfo/issue-12886.rs
@@ -11,7 +11,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 // IF YOU MODIFY THIS FILE, BE CAREFUL TO ADAPT THE LINE NUMBERS IN THE DEBUGGER COMMANDS
 

--- a/src/test/debuginfo/lexical-scope-in-for-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-for-loop.rs
@@ -84,7 +84,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-if.rs
+++ b/src/test/debuginfo/lexical-scope-in-if.rs
@@ -141,7 +141,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-match.rs
+++ b/src/test/debuginfo/lexical-scope-in-match.rs
@@ -135,7 +135,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct Struct {
     x: isize,

--- a/src/test/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-stack-closure.rs
@@ -67,7 +67,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -136,7 +136,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-unique-closure.rs
@@ -68,7 +68,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-while.rs
+++ b/src/test/debuginfo/lexical-scope-in-while.rs
@@ -136,7 +136,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -112,7 +112,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 macro_rules! trivial {
     ($e1:expr) => ($e1)

--- a/src/test/debuginfo/multiple-functions-equal-var-names.rs
+++ b/src/test/debuginfo/multiple-functions-equal-var-names.rs
@@ -39,7 +39,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn function_one() {
     let abc = 10101;

--- a/src/test/debuginfo/multiple-functions.rs
+++ b/src/test/debuginfo/multiple-functions.rs
@@ -39,7 +39,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn function_one() {
     let a = 10101;

--- a/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -97,7 +97,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -16,7 +16,7 @@
 #![feature(no_debug)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 #[inline(never)]
 fn id<T>(x: T) -> T {x}

--- a/src/test/debuginfo/packed-struct-with-destructor.rs
+++ b/src/test/debuginfo/packed-struct-with-destructor.rs
@@ -81,7 +81,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -62,7 +62,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/pretty-huge-vec.rs
+++ b/src/test/debuginfo/pretty-huge-vec.rs
@@ -17,7 +17,7 @@
 
 
 #![allow(unused_variables)]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -65,7 +65,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Opt::{Empty, Val};
 

--- a/src/test/debuginfo/shadowed-argument.rs
+++ b/src/test/debuginfo/shadowed-argument.rs
@@ -56,7 +56,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn a_function(x: bool, y: bool) {
     zzz(); // #break

--- a/src/test/debuginfo/shadowed-variable.rs
+++ b/src/test/debuginfo/shadowed-variable.rs
@@ -81,7 +81,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -57,7 +57,7 @@
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 #![feature(repr_simd)]
-#![no_trace]
+#![no_sw_trace]
 
 #[repr(simd)]
 struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);

--- a/src/test/debuginfo/simple-lexical-scope.rs
+++ b/src/test/debuginfo/simple-lexical-scope.rs
@@ -77,7 +77,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let x = false;

--- a/src/test/debuginfo/struct-in-struct.rs
+++ b/src/test/debuginfo/struct-in-struct.rs
@@ -59,7 +59,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct Simple {
     x: i32

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -45,7 +45,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/struct-with-destructor.rs
+++ b/src/test/debuginfo/struct-with-destructor.rs
@@ -46,7 +46,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct NoDestructor {
     x: i32,

--- a/src/test/debuginfo/tuple-in-struct.rs
+++ b/src/test/debuginfo/tuple-in-struct.rs
@@ -44,7 +44,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct NoPadding1 {
     x: (i32, i32),

--- a/src/test/debuginfo/tuple-in-tuple.rs
+++ b/src/test/debuginfo/tuple-in-tuple.rs
@@ -62,7 +62,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     let no_padding1: ((u32, u32), u32, u32) = ((0, 1), 2, 3);

--- a/src/test/debuginfo/tuple-struct.rs
+++ b/src/test/debuginfo/tuple-struct.rs
@@ -68,7 +68,7 @@
 
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 struct NoPadding16(u16, i16);
 struct NoPadding32(i32, f32, u32);

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -45,7 +45,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -37,7 +37,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -87,7 +87,7 @@
 #![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![no_trace]
+#![no_sw_trace]
 
 
 struct Struct {

--- a/src/test/incremental/change_add_field/struct_point.rs
+++ b/src/test/incremental/change_add_field/struct_point.rs
@@ -11,7 +11,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 // These are expected to require codegen.
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]

--- a/src/test/incremental/change_private_fn/struct_point.rs
+++ b/src/test/incremental/change_private_fn/struct_point.rs
@@ -9,7 +9,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_private_fn_cc/struct_point.rs
+++ b/src/test/incremental/change_private_fn_cc/struct_point.rs
@@ -10,7 +10,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
 #![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]

--- a/src/test/incremental/change_private_impl_method/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method/struct_point.rs
@@ -9,7 +9,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_private_impl_method_cc/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method_cc/struct_point.rs
@@ -10,7 +10,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
 #![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]

--- a/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -8,7 +8,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
 

--- a/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -8,7 +8,7 @@
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]
 #![allow(dead_code)]
-#![no_trace]
+#![no_sw_trace]
 
 // These are expected to require codegen.
 #![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]

--- a/src/test/incremental/change_symbol_export_status.rs
+++ b/src/test/incremental/change_symbol_export_status.rs
@@ -6,7 +6,7 @@
 
 #![rustc_partition_codegened(module="change_symbol_export_status-mod1", cfg="rpass2")]
 #![rustc_partition_reused(module="change_symbol_export_status-mod2", cfg="rpass2")]
-#![no_trace]
+#![no_sw_trace]
 
 // This test case makes sure that a change in symbol visibility is detected by
 // our dependency tracking. We do this by changing a module's visibility to

--- a/src/test/incremental/hashes/closure_expressions.rs
+++ b/src/test/incremental/hashes/closure_expressions.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Change closure body ---------------------------------------------------------

--- a/src/test/incremental/hashes/enum_constructors.rs
+++ b/src/test/incremental/hashes/enum_constructors.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 pub enum Enum {

--- a/src/test/incremental/hashes/for_loops.rs
+++ b/src/test/incremental/hashes/for_loops.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/function_interfaces.rs
+++ b/src/test/incremental/hashes/function_interfaces.rs
@@ -15,7 +15,7 @@
 #![feature(linkage)]
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Add Parameter ---------------------------------------------------------------

--- a/src/test/incremental/hashes/if_expressions.rs
+++ b/src/test/incremental/hashes/if_expressions.rs
@@ -13,7 +13,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 // Change condition (if) -------------------------------------------------------
 #[cfg(cfail1)]

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -13,7 +13,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 pub struct Foo;
 

--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -13,7 +13,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 // Change Name -----------------------------------------------------------------
 #[cfg(cfail1)]

--- a/src/test/incremental/hashes/loop_expressions.rs
+++ b/src/test/incremental/hashes/loop_expressions.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/struct_constructors.rs
+++ b/src/test/incremental/hashes/struct_constructors.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 pub struct RegularStruct {

--- a/src/test/incremental/hashes/while_let_loops.rs
+++ b/src/test/incremental/hashes/while_let_loops.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/hashes/while_loops.rs
+++ b/src/test/incremental/hashes/while_loops.rs
@@ -12,7 +12,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 
 // Change loop body ------------------------------------------------------------

--- a/src/test/incremental/issue-38222.rs
+++ b/src/test/incremental/issue-38222.rs
@@ -14,7 +14,7 @@
 // be re-used, so checking that this module was re-used is sufficient.
 #![rustc_partition_reused(module="issue_38222", cfg="rpass2")]
 
-#![no_trace]
+#![no_sw_trace]
 
 //[rpass1] compile-flags: -C debuginfo=1
 //[rpass2] compile-flags: -C debuginfo=1

--- a/src/test/incremental/issue-42602.rs
+++ b/src/test/incremental/issue-42602.rs
@@ -11,7 +11,7 @@
 // compile-pass
 
 #![feature(rustc_attrs)]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     a::foo();

--- a/src/test/incremental/krate-inherent.rs
+++ b/src/test/incremental/krate-inherent.rs
@@ -6,7 +6,7 @@
 #![feature(rustc_attrs)]
 #![rustc_partition_reused(module="krate_inherent-x", cfg="cfail2")]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 pub mod x {
     pub struct Foo;

--- a/src/test/incremental/krate-inlined.rs
+++ b/src/test/incremental/krate-inlined.rs
@@ -8,7 +8,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![rustc_partition_reused(module="krate_inlined-x", cfg="rpass2")]
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     x::method();

--- a/src/test/incremental/remapped_paths_cc/main.rs
+++ b/src/test/incremental/remapped_paths_cc/main.rs
@@ -6,7 +6,7 @@
 // are changed, even when the change happens in an external crate.
 
 #![feature(rustc_attrs)]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_reused(module="main", cfg="rpass2")]
 #![rustc_partition_reused(module="main-some_mod", cfg="rpass2")]

--- a/src/test/incremental/remove-private-item-cross-crate/main.rs
+++ b/src/test/incremental/remove-private-item-cross-crate/main.rs
@@ -7,7 +7,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type = "bin"]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_partition_reused(module="main", cfg="rpass2")]
 

--- a/src/test/incremental/spans_in_type_debuginfo.rs
+++ b/src/test/incremental/spans_in_type_debuginfo.rs
@@ -8,7 +8,7 @@
 #![rustc_partition_reused(module="spans_in_type_debuginfo-enums", cfg="rpass2")]
 
 #![feature(rustc_attrs)]
-#![no_trace]
+#![no_sw_trace]
 
 mod structs {
     #[cfg(rpass1)]

--- a/src/test/incremental/spike.rs
+++ b/src/test/incremental/spike.rs
@@ -10,7 +10,7 @@
 #![rustc_partition_reused(module="spike", cfg="rpass2")]
 #![rustc_partition_codegened(module="spike-x", cfg="rpass2")]
 #![rustc_partition_reused(module="spike-y", cfg="rpass2")]
-#![no_trace]
+#![no_sw_trace]
 
 mod x {
     pub struct X {

--- a/src/test/incremental/string_constant.rs
+++ b/src/test/incremental/string_constant.rs
@@ -5,7 +5,7 @@
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 // Here the only thing which changes is the string constant in `x`.
 // Therefore, the compiler deduces (correctly) that typeck is not

--- a/src/test/incremental/thinlto/cgu_invalidated_via_import.rs
+++ b/src/test/incremental/thinlto/cgu_invalidated_via_import.rs
@@ -8,7 +8,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-foo",
                             cfg="cfail2",

--- a/src/test/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
+++ b/src/test/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
@@ -7,7 +7,7 @@
 
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
-#![no_trace]
+#![no_sw_trace]
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-foo",
                             cfg="cfail2",

--- a/src/test/mir-opt/inline-any-operand.rs
+++ b/src/test/mir-opt/inline-any-operand.rs
@@ -2,7 +2,7 @@
 
 // Tests that MIR inliner works for any operand
 
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     println!("{}", bar());

--- a/src/test/mir-opt/inline-closure-borrows-arg.rs
+++ b/src/test/mir-opt/inline-closure-borrows-arg.rs
@@ -4,7 +4,7 @@
 // Tests that MIR inliner can handle closure arguments,
 // even when (#45894)
 
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     println!("{}", foo(0, &14));

--- a/src/test/mir-opt/inline-closure.rs
+++ b/src/test/mir-opt/inline-closure.rs
@@ -3,7 +3,7 @@
 
 // Tests that MIR inliner can handle closure arguments. (#45894)
 
-#![no_trace]
+#![no_sw_trace]
 
 fn main() {
     println!("{}", foo(0, 14));

--- a/src/test/mir-opt/inline-trait-method_2.rs
+++ b/src/test/mir-opt/inline-trait-method_2.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Z span_free_formats -Z mir-opt-level=3
 
-#![no_trace]
+#![no_sw_trace]
 
 fn test2(x: &dyn X) -> bool {
     test(x)

--- a/src/test/run-make-fulldeps/inline-always-many-cgu/foo.rs
+++ b/src/test/run-make-fulldeps/inline-always-many-cgu/foo.rs
@@ -1,5 +1,5 @@
 #![crate_type = "lib"]
-#![no_trace]
+#![no_sw_trace]
 
 pub mod a {
     #[inline(always)]

--- a/src/test/run-make/yk-sir-section/Makefile
+++ b/src/test/run-make/yk-sir-section/Makefile
@@ -1,7 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
 all:
-	# We unset YK_NO_SIR (if set) as this test really needs SIR.
-	unset YK_NO_SIR && $(RUSTC) sir_sec.rs
+	# A tracer must be enabled for SIR to be emitted.
+	YK_TRACER=sw && $(RUSTC) sir_sec.rs
 	# Exit non-zero if there was no Yorick TIR section in the binary.
 	[ "`readelf --section-headers ${TMPDIR}/sir_sec | grep yk_sir | wc -l`" != 0 ]

--- a/src/test/run-pass/thinlto/thin-lto-inlines.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines.rs
@@ -8,7 +8,7 @@
 // praying two functions go into separate codegen units and then assuming that
 // if inlining *doesn't* happen the first byte of the functions will differ.
 
-#![no_trace]
+#![no_sw_trace]
 
 pub fn foo() -> u32 {
     bar::bar()

--- a/src/test/run-pass/thinlto/thin-lto-inlines2.rs
+++ b/src/test/run-pass/thinlto/thin-lto-inlines2.rs
@@ -10,7 +10,7 @@
 // praying two functions go into separate codegen units and then assuming that
 // if inlining *doesn't* happen the first byte of the functions will differ.
 
-#![no_trace]
+#![no_sw_trace]
 
 extern crate thin_lto_inlines_aux as bar;
 

--- a/src/test/yk-sir/simple_sir.rs
+++ b/src/test/yk-sir/simple_sir.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-#[no_trace]
+#[no_sw_trace]
 fn main() {
     let x = env::args().count();
     let mut res = 42;

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3536,9 +3536,8 @@ impl<'test> TestCx<'test> {
     }
 
     fn run_yk_sir_test(&self) {
-        // We build the compiler with SIR emission disabled (because it is slow), but these tests
-        // really do need the SIR.
-        env::remove_var("YK_NO_SIR");
+        // A tracer must be enabled for SIR to be emitted.
+        env::set_var("YK_TRACER", "sw");
 
         let proc_res = self.compile_test();
 


### PR DESCRIPTION
This PR adds yorick labels to basic MIR blocks which should allow us match them against traces in the future.

Though this PR is likely not ready to be merged yet, I have opened it to make it easier to discuss what needs to be done next.