### PR TITLE
Implement and use a query to help us find MIR in dependent crates.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -11,7 +11,7 @@ TARBALL_NAME=ykrustc-stage2-latest.tar.bz2
 SNAP_DIR=/opt/ykrustc-bin-snapshots
 
 # Ensure the build fails if it uses excessive amounts of memory.
-ulimit -d $((1024 * 1024 * 8)) # 8 GiB
+ulimit -d $((1024 * 1024 * 12)) # 12 GiB
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -709,6 +709,9 @@ rustc_queries! {
         }
         query upstream_monomorphizations_for(_: DefId)
             -> Option<&'tcx FxHashMap<SubstsRef<'tcx>, CrateNum>> {}
+        query defids_with_mir(k: CrateNum) -> DefIdSet {
+            desc { "collecting codegenned indices that have MIR encoded" }
+        }
     }
 
     Other {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -6,7 +6,7 @@ use log::{debug, info, warn, log_enabled};
 use rustc::dep_graph::DepGraph;
 use rustc::hir;
 use rustc::hir::lowering::lower_crate;
-use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
+use rustc::hir::def_id::{CrateNum, LOCAL_CRATE, DefId, DefIndex};
 use rustc::lint;
 use rustc::middle::{self, reachable, resolve_lifetime, stability};
 use rustc::middle::privacy::AccessLevels;
@@ -58,6 +58,7 @@ use serialize::json;
 use tempfile::Builder as TempFileBuilder;
 
 use std::any::Any;
+use std::borrow::Borrow;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -1102,7 +1103,11 @@ pub fn start_codegen<'tcx>(
 
     // Output Yorick debug sections into binary targets.
     if tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
-        let (def_ids, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
+        let def_ids = tcx.collect_and_partition_mono_items(LOCAL_CRATE).0;
+        let mut def_ids = (*def_ids).clone();
+        for cnum in tcx.crates() {
+            def_ids.extend(tcx.defids_with_mir(*cnum));
+        }
         let sir_mode = if tcx.sess.opts.output_types.contains_key(&OutputType::YkSir) {
             // The user passed "--emit yk-sir" so we will output textual SIR and stop.
             SirMode::TextDump(outputs.path(OutputType::YkSir))

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -245,6 +245,10 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     used_crate_source => { Lrc::new(cdata.source.clone()) }
 
     exported_symbols => { Arc::new(cdata.exported_symbols(tcx)) }
+
+    defids_with_mir => {
+        cdata.defids_with_mir(tcx)
+    }
 }
 
 pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {


### PR DESCRIPTION
The new query returns a set of DefIds which:
 * Have an entry in the definition path table in the metadata.
 * Have MIR available.

At serialisation time, we then iterate over all dependent crates, adding
new DefIds into the list of things to be serialized.

I've not run the tests all the way yet, so we may encounter a couple of test failures. Can fix along the way.

(Following this merge, there will be a house-keeping PR where I clean up some old code we no-longer need).