### PR TITLE
Replace YK_TRACER with a proper tracked compiler flag.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -5,11 +5,9 @@
 set -e
 
 export PATH=PATH=/opt/gdb-8.2/bin:${PATH}
-# For now we only test the software tracer in CI. We use `sw-nosir` below so
-# that the standard library is software-tracing ready, but the compiler
-# binaries themselves do not contain SIR (making SIR really slows down testing,
-# and it isn't necessary for the compiler itself anyway).
-export YK_TRACER=sw-nosir
+# Select which kind of traceable std lib to build.
+# FIXME eventually CI will test both modes and thus set this itself.
+export STD_TRACER_MODE=sw
 
 TARBALL_TOPDIR=`pwd`/build/ykrustc-stage2-latest
 TARBALL_NAME=ykrustc-stage2-latest.tar.bz2

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -230,6 +230,19 @@ pub fn std_cargo(builder: &Builder<'_>,
                 cargo.env("WASI_ROOT", p);
             }
         }
+
+        // We have to build a standard library for the kind of Yorick tracer we want to use.
+        // Why? Because to trace through std and core, we need:
+        //  * For the software tracer, code with calls to the trace recorder.
+        //  * For the hardware tracer, DILabels to help mapping back to SIR.
+        if compiler.stage != 0 {
+            match env::var("STD_TRACER_MODE") {
+                Err(_) => panic!("STD_TRACER_MODE must be set"),
+                Ok(val) => {
+                    cargo.env("RUSTFLAGS", format!("-C tracer={}", val));
+                }
+            }
+        }
     }
 }
 

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -11,7 +11,6 @@ use crate::common::{self, IntPredicate};
 use crate::meth;
 
 use std::ffi::CString;
-use std::env;
 
 use crate::traits::*;
 
@@ -804,16 +803,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         debug!("codegen_block({:?}={:?})", bb, data);
 
-        let tracer = match env::var("YK_TRACER") {
-            Ok(val) => match val.as_str() {
-                "hw" => true,
-                "sw" | "sw-nosir" => false,
-                unknown => panic!("Invalid YK_TRACER environment: {}", unknown),
-            }
-            Err(_) => false
-        };
-
-        if tracer && bx.cx().has_debug() {
+        if bx.cx().tcx().sess.opts.cg.tracer.sir_labels() && bx.cx().has_debug() {
             let did = self.instance.def.def_id();
             let lbl_name = CString::new(format!("__YK_BLK_{}_{}_{}", did.krate.as_u32(),
                                         did.index.as_u32(), bb.index())).unwrap();

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1102,24 +1102,9 @@ pub fn start_codegen<'tcx>(
     }
 
     // Output Yorick debug sections into binary targets if necessary.
-    // FIXME: YK_TRACER should eventually be a proper compiler flag and there should be a function
-    // for asking which tracer is being used. Then all places reading YK_TRACER can use that
-    // instead.
-    let enc_sir = match env::var("YK_TRACER") {
-        Ok(val) => {
-            match val.as_str() {
-                "hw" | "sw" => true,
-                // We use `sw-nosir` when building the compiler itself for software tracing.
-                // There's no need to encode SIR into compiler tools and it would make the
-                // build/test cycle very slow.
-                "sw-nosir" => false,
-                unknown => panic!("Invalid YK_TRACER environment: {}", unknown)
-            }
-        },
-        Err(_) => false,
-    };
-
-    if enc_sir && tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) {
+    if tcx.sess.opts.cg.tracer.encode_sir() &&
+        tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable)
+    {
         let def_ids = tcx.collect_and_partition_mono_items(LOCAL_CRATE).0;
         let mut def_ids = (*def_ids).clone();
         for cnum in tcx.crates() {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -24,7 +24,6 @@ use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_serialize::{Encodable, Encoder, SpecializedEncoder, opaque};
 
-use std::env;
 use std::hash::Hash;
 use std::path::Path;
 use rustc_data_structures::sync::Lrc;
@@ -63,20 +62,6 @@ macro_rules! encoder_methods {
         $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
             self.opaque.$name(value)
         })*
-    }
-}
-
-/// A check to see if we are using a Yorick tracer. Used to decide whether we need to encode MIR
-/// for all items.
-fn building_with_yk_tracer() -> bool {
-    match env::var("YK_TRACER") {
-        Ok(val) => {
-            match val.as_str() {
-                "hw" | "sw" | "sw-nosir" => true,
-                unknown => panic!("Bad YK_TRACER environment: {}", unknown),
-            }
-        },
-        Err(_) => false,
     }
 }
 
@@ -995,7 +980,7 @@ impl EncodeContext<'_, 'tcx> {
                                         !self.metadata_output_only();
                     let is_const_fn = sig.header.constness == hir::Constness::Const;
                     let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir
-                        || building_with_yk_tracer();
+                        || self.tcx.sess.opts.cg.tracer.encode_sir();
                     needs_inline || is_const_fn || always_encode_mir
                 },
                 hir::ImplItemKind::Existential(..) |
@@ -1314,7 +1299,7 @@ impl EncodeContext<'_, 'tcx> {
                          tcx.codegen_fn_attrs(def_id).requests_inline()) &&
                             !self.metadata_output_only();
                     let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir
-                        || building_with_yk_tracer();
+                        || self.tcx.sess.opts.cg.tracer.encode_sir();
                     if needs_inline
                         || header.constness == hir::Constness::Const
                         || always_encode_mir

--- a/src/test/run-make/yk-sir-section/Makefile
+++ b/src/test/run-make/yk-sir-section/Makefile
@@ -2,6 +2,6 @@
 
 all:
 	# A tracer must be enabled for SIR to be emitted.
-	YK_TRACER=sw && $(RUSTC) sir_sec.rs
+	$(RUSTC) -C tracer=sw sir_sec.rs
 	# Exit non-zero if there was no Yorick TIR section in the binary.
 	[ "`readelf --section-headers ${TMPDIR}/sir_sec | grep yk_sir | wc -l`" != 0 ]

--- a/src/test/run-pass/yk_swt/collect-trace-twice.rs
+++ b/src/test/run-pass/yk_swt/collect-trace-twice.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -C tracer=sw
+
 #![feature(yk_swt)]
 #![feature(libc)]
 #![feature(test)]

--- a/src/test/run-pass/yk_swt/collect-trace.rs
+++ b/src/test/run-pass/yk_swt/collect-trace.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -C tracer=sw
+
 #![feature(yk_swt)]
 #![feature(libc)]
 #![feature(test)]

--- a/src/test/run-pass/yk_swt/collect-traces-threaded.rs
+++ b/src/test/run-pass/yk_swt/collect-traces-threaded.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -C tracer=sw
+
 #![feature(yk_swt)]
 #![feature(libc)]
 #![feature(test)]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1548,7 +1548,7 @@ impl<'test> TestCx<'test> {
                 if !self.config.src_base.ends_with("rustdoc-ui") {
                     rustc.args(&["-A", "unused"]);
                 }
-            }
+            },
             _ => {}
         }
 
@@ -1967,7 +1967,7 @@ impl<'test> TestCx<'test> {
                 rustc.arg(dir_opt);
             }
             YkSir => {
-                rustc.args(&[ "--emit", "yk-sir"]);
+                rustc.args(&[ "--emit", "yk-sir", "-C", "tracer=sw"]);
 
                 let mir_dump_dir = self.get_mir_dump_dir();
                 let _ = fs::remove_dir_all(&mir_dump_dir);
@@ -3536,9 +3536,6 @@ impl<'test> TestCx<'test> {
     }
 
     fn run_yk_sir_test(&self) {
-        // A tracer must be enabled for SIR to be emitted.
-        env::set_var("YK_TRACER", "sw");
-
         let proc_res = self.compile_test();
 
         if !proc_res.status.success() {


### PR DESCRIPTION
See the commit message for a detailed description of this change.

We may even get a small CI speed up, as all ykrustc code that is *not* the standard library will not have calls to the trace recorder any more. As we discussed before, we never need to trace the compiler itself.