### PR TITLE
Build separate tarballs for hardware- and software-enabled ykrustc.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,10 +4,16 @@
 
 set -e
 
+case ${STD_TRACER_MODE} in
+    "sw" | "hw") true;;
+    *) echo "STD_TRACER_MODE must be set to either 'hw' or 'sw'"
+       exit 1;;
+esac
+
 export PATH=PATH=/opt/gdb-8.2/bin:${PATH}
 
 TARBALL_TOPDIR=`pwd`/build/ykrustc-stage2-latest
-TARBALL_NAME=ykrustc-stage2-latest.tar.bz2
+TARBALL_NAME=ykrustc-${STD_TRACER_MODE}-stage2-latest.tar.bz2
 SNAP_DIR=/opt/ykrustc-bin-snapshots
 
 # Ensure the build fails if it uses excessive amounts of memory.


### PR DESCRIPTION
This makes the CI for ykrustc build two separate tarballs for each tracer mode.

Eventually the `yk` repo will have parallel CI which will pick up these two tarballs.

I suggest we wait until we've made the yksom CI changes before kicking bors on this one. When the time comes, we can do a `try` and I can check the local filesystem on the CI server. If it works, we can `r+` it.