### PR TITLE
Test hwtracer

### DIFF
--- a/src/test/run-make/yk-rustc-hwtracer/Makefile
+++ b/src/test/run-make/yk-rustc-hwtracer/Makefile
@@ -1,0 +1,8 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) -C tracer=hw block.rs 
+	[ "`dwarfdump ${TMPDIR}/block | grep __YK_BLK | wc -l`" -ne 0 ]
+
+	$(RUSTC) -C tracer=sw block.rs 
+	[ "`dwarfdump ${TMPDIR}/block | grep __YK_BLK | wc -l`" -eq 0 ]

--- a/src/test/run-make/yk-rustc-hwtracer/block.rs
+++ b/src/test/run-make/yk-rustc-hwtracer/block.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let x = 1234;
+    if x == 1234 {
+        println!("1234");
+    }
+    foo();
+}
+
+fn foo() {
+    println!("foo");
+}


### PR DESCRIPTION
Requires #52 to be merged first.

Test that the hardware and software tracing flags are working.