### PR TITLE
Remove the work loop from the SIR encoding code.

### DIFF
--- a/src/librustc_yk_sections/emit_sir.rs
+++ b/src/librustc_yk_sections/emit_sir.rs
@@ -20,7 +20,6 @@ use rustc::mir::{
     Body, Local, BasicBlockData, Statement, StatementKind, Place, PlaceBase, Rvalue, Operand,
     Terminator, TerminatorKind, Constant, BinOp, NullOp
 };
-use rustc::middle::lang_items::ExchangeMallocFnLangItem;
 use rustc::mir::interpret::{ConstValue, Scalar};
 use rustc::util::nodemap::DefIdSet;
 use std::path::PathBuf;
@@ -58,8 +57,6 @@ struct ConvCx<'a, 'tcx> {
     mir: &'a Body<'tcx>,
     /// The DefId of the above MIR.
     def_id: DefId,
-    /// We keep track of the DefIds that each Body calls so that we can process them later.
-    callee_def_ids: DefIdSet,
 }
 
 impl<'a, 'tcx> ConvCx<'a, 'tcx> {
@@ -70,7 +67,6 @@ impl<'a, 'tcx> ConvCx<'a, 'tcx> {
             var_map: IndexVec::new(),
             mir,
             def_id,
-            callee_def_ids: DefIdSet::default(),
         }
     }
 
@@ -103,11 +99,10 @@ impl<'a, 'tcx> ConvCx<'a, 'tcx> {
     }
 
     /// Entry point for the lowering process.
-    fn lower(mut self) -> (ykpack::Body, DefIdSet) {
+    fn lower(mut self) -> ykpack::Body {
         let dps = self.tcx.def_path_str(self.def_id);
-        let body = ykpack::Body::new(self.lower_def_id(&self.def_id.to_owned()),
-            dps, self.mir.basic_blocks().iter().map(|b| self.lower_block(b)).collect());
-        (body, self.callee_def_ids)
+        ykpack::Body::new(self.lower_def_id(&self.def_id.to_owned()),
+            dps, self.mir.basic_blocks().iter().map(|b| self.lower_block(b)).collect())
     }
 
     fn lower_def_id(&mut self, def_id: &DefId) -> ykpack::DefId {
@@ -176,7 +171,6 @@ impl<'a, 'tcx> ConvCx<'a, 'tcx> {
                         true => None,
                         false => Some(String::from(&*self.tcx.symbol_name(inst).name.as_str())),
                     };
-                    self.callee_def_ids.insert(*target_def_id);
                     ykpack::CallOperand::Fn(self.lower_def_id(target_def_id), sym_name)
                 } else {
                     // FIXME -- implement other callables.
@@ -255,10 +249,7 @@ impl<'a, 'tcx> ConvCx<'a, 'tcx> {
                 Ok(ykpack::Rvalue::BinaryOp(self.lower_binary_op(*bin_op), self.lower_operand(o1)?,
                     self.lower_operand(o2)?)),
             Rvalue::NullaryOp(NullOp::Box, _) => {
-                let def_id = self.tcx.lang_items()
-                    .require(ExchangeMallocFnLangItem)
-                    .expect("can't find DefId for ExchangeMallocFnLangItem");
-                self.callee_def_ids.insert(def_id);
+                // This is actually a call to ExchangeMallocFnLangItem.
                 Err(()) // FIXME: decide how to lower boxes.
             },
             _ => Err(()),
@@ -404,41 +395,27 @@ fn do_generate_sir<'tcx>(
         _ => None,
     };
 
-    // We use a worklist because as we lower MIR bodies we will discover further DefIds (e.g. call
-    // targets) which in turn will need to be processed. However, to satisfy the reproducible build
-    // tests, we must process the DefIds in a deterministic order. To that end all newly discovered
-    // work must be sorted before it is appended into the work list.
-    let mut work: Vec<DefId> = def_ids.iter().cloned().collect();
-    work.sort();
-    let mut seen =  DefIdSet::default();
-    while !work.is_empty() {
-        let def_id = work.pop().unwrap();
-        if seen.contains(&def_id) {
-            continue;
-        }
+    // We must process the DefIds in deterministic order for reproducible builds.
+    let mut def_ids: Vec<&DefId> = def_ids.iter().collect();
+    def_ids.sort();
 
-        if tcx.is_mir_available(def_id) {
-            let mir = tcx.optimized_mir(def_id);
-            let ccx = ConvCx::new(tcx, def_id, mir);
-            let (pack, mut extra_work) = ccx.lower();
+    for def_id in def_ids {
+        if tcx.is_mir_available(*def_id) {
+            let mir = tcx.optimized_mir(*def_id);
+            let ccx = ConvCx::new(tcx, *def_id, mir);
+            let pack = ccx.lower();
 
             if let Some(ref mut e) = enc {
                 e.serialise(ykpack::Pack::Body(pack))?;
             } else {
                 write!(textdump_file.as_ref().unwrap(), "{}", pack)?;
             }
-
-            let mut extra_work: Vec<DefId> = extra_work.drain().collect();
-            extra_work.sort();
-            work.extend(extra_work);
         }
 
         if let Some(ref mut e) = enc {
             e.serialise(ykpack::Pack::Debug(ykpack::SirDebug::new(
-                lower_def_id(tcx, &def_id), tcx.def_path_str(def_id))))?;
+                lower_def_id(tcx, def_id), tcx.def_path_str(*def_id))))?;
         }
-
-        seen.insert(def_id);
     }
 
     if let Some(e) = enc {


### PR DESCRIPTION
This change removes the work list from the SIR encoding section of ykrustc. We used to try and find things to encode by following calls in the MIR, but now we have a different way of doing this.

Assigning to @ptersilie as @ltratt is away today.