### PR TITLE
Compiler support for trace trimming.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,6 +3778,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_yk_link",
  "syntax",
+ "syntax_pos",
  "ykpack",
 ]
 
@@ -5080,7 +5081,6 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#0ff2fb8799120c9b77660c5b6de922aa206c0f43"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -17,3 +17,4 @@ ykpack = { git = "https://github.com/softdevteam/yk" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 syntax = { path = "../libsyntax" }
+syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 [dependencies]
 rustc = { path = "../librustc" }
 rustc_yk_link = { path = "../librustc_yk_link" }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { git = "https://github.com/vext01/yk", rev="183319f8d558473a64fc3351523264ff82183ab7" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 syntax = { path = "../libsyntax" }

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -239,6 +239,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // "Don't software trace this". Disables the `AddYkSWTCalls` MIR transform.
     ungated!(no_sw_trace, Whitelisted, template!(Word)),
 
+    // Markers for trimming traces.
+    ungated!(trace_head, Whitelisted, template!(Word)),
+    ungated!(trace_tail, Whitelisted, template!(Word)),
+
     ungated!(used, Whitelisted, template!(Word)),
 
     // Limits:

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -447,6 +447,8 @@ symbols! {
         no_implicit_prelude,
         no_inline,
         no_sw_trace,
+        trace_head,
+        trace_tail,
         no_link,
         no_main,
         no_mangle,

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -30,7 +30,13 @@ pub fn check(path: &Path, bad: &mut bool) {
         let source = line.splitn(2, '=').nth(1).unwrap().trim();
 
         // Allow all soft-dev repos.
-        if source.starts_with("\"git+https://github.com/softdevteam") {
+        // We also allow our personal forks for scenarios where we are breaking a CI cycle and need
+        // to temporarily use one of our personal feature branches.
+        if source.starts_with("\"git+https://github.com/softdevteam/") ||
+            source.starts_with("\"git+https://github.com/vext01/") ||
+            source.starts_with("\"git+https://github.com/ltratt/") ||
+            source.starts_with("\"git+https://github.com/ptersilie/")
+        {
             continue;
         }
 


### PR DESCRIPTION
When serialising the SIR, we set flags for items marked `#[trace_head]`
and `#[trace_tail]`.

For more info, see:
https://github.com/softdevteam/yk/pull/26

Again, this forms a CI cycle. We need to discuss before merging.