### PR TITLE
Simplify label generation

### DIFF
--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -1,7 +1,7 @@
 use rustc::middle::lang_items;
 use rustc::ty::{self, Ty, TypeFoldable, Instance};
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt, FnTypeExt};
-use rustc::mir::{self, Place, PlaceBase, Static, StaticKind, Location};
+use rustc::mir::{self, Place, PlaceBase, Static, StaticKind};
 use rustc::mir::interpret::PanicInfo;
 use rustc_target::abi::call::{ArgType, FnType, PassMode, IgnoreMode};
 use rustc_target::spec::abi::Abi;
@@ -817,13 +817,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             let did = self.instance.def.def_id();
             let lbl_name = CString::new(format!("__YK_BLK_{}_{}_{}", did.krate.as_u32(),
                                         did.index.as_u32(), bb.index())).unwrap();
-
-            // Get the sub_program.
-            // FIXME must be an easier way.
-            let loc = Location{block: bb, statement_index: 0};
-            let source_info = self.mir.source_info(loc);
-            let (_, span) = self.debug_loc(*source_info);
-            let di_sp = self.fn_metadata(span);
+            let di_sp = self.fn_metadata(data.terminator().source_info.span);
             bx.add_yk_block_label_at_end(*di_sp, lbl_name);
         }
 


### PR DESCRIPTION
This PR simplifies the way we get the `DIScope` in order to create YK block labels.