### PR TITLE
Skip build scripts

### DIFF
--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1107,7 +1107,7 @@ pub fn start_codegen<'tcx>(
         }
     }
 
-    // Output Yorick debug sections into binary targets if necessary.
+    // Output Yorick sections into binary targets if necessary.
     if tcx.sess.opts.cg.tracer.encode_sir() &&
         tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) &&
         tcx.crate_name(LOCAL_CRATE).as_str() != "build_script_build"

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1109,7 +1109,8 @@ pub fn start_codegen<'tcx>(
 
     // Output Yorick debug sections into binary targets if necessary.
     if tcx.sess.opts.cg.tracer.encode_sir() &&
-        tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable)
+        tcx.sess.crate_types.borrow().contains(&config::CrateType::Executable) &&
+        tcx.crate_name(LOCAL_CRATE).as_str() != "build_script_build"
     {
         let def_ids = tcx.collect_and_partition_mono_items(LOCAL_CRATE).0;
         let mut def_ids = (*def_ids).clone();


### PR DESCRIPTION
Here's a micro-optimisation. There's no need to encode SIR in build script binaries.

Fix a comment while we are here.