### PR TITLE
Don't generate labels if there is no DIScope

### DIFF
--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -149,8 +149,9 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'a, 'tcx> {
                     let crate_hash = bx.cx().tcx().crate_hash(did.krate).as_u64();
                     let lbl_name = CString::new(format!("__YK_RET_{}_{}_{}", crate_hash,
                                                 did.index.as_u32(), self.bb.index())).unwrap();
-                    let di_sp = fx.fn_metadata(self.terminator.source_info);
-                    bx.add_yk_block_label_at_end(di_sp, lbl_name);
+                    if let Some(di_sp) = fx.fn_metadata(self.terminator.source_info) {
+                        bx.add_yk_block_label_at_end(di_sp, lbl_name);
+                    }
                 }
 
                 fx.store_return(bx, ret_dest, &fn_abi.ret, llret);
@@ -804,8 +805,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             let crate_hash = bx.cx().tcx().crate_hash(did.krate).as_u64();
             let lbl_name = CString::new(format!("__YK_BLK_{}_{}_{}", crate_hash,
                                         did.index.as_u32(), bb.index())).unwrap();
-            let di_sp = self.fn_metadata(data.terminator().source_info);
-            bx.add_yk_block_label_at_end(di_sp, lbl_name);
+            if let Some(di_sp) = self.fn_metadata(data.terminator().source_info) {
+                bx.add_yk_block_label_at_end(di_sp, lbl_name);
+            }
         }
 
         for statement in &data.statements {

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -88,8 +88,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         )
     }
 
-    pub fn fn_metadata(&self, source_info: SourceInfo) -> Bx::DIScope {
-        self.debug_context.as_ref().unwrap().scopes[source_info.scope].scope_metadata.unwrap()
+    pub fn fn_metadata(&self, source_info: SourceInfo) -> Option<Bx::DIScope> {
+        let (odisp, _span) = self.debug_loc(source_info);
+        odisp
     }
 }
 

--- a/src/test/run-make/yk-cargotest-hwtracer/Makefile
+++ b/src/test/run-make/yk-cargotest-hwtracer/Makefile
@@ -1,0 +1,6 @@
+-include ../../run-make-fulldeps/tools.mk
+
+export RUSTC := $(RUSTC_ORIGINAL)
+
+all:
+	cd run && [ "`RUSTFLAGS='-C tracer=hw' $$CARGO test | grep 'result: ok' | wc -l `" -eq 1 ]

--- a/src/test/run-make/yk-cargotest-hwtracer/run/Cargo.toml
+++ b/src/test/run-make/yk-cargotest-hwtracer/run/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "run"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+
+[workspace]

--- a/src/test/run-make/yk-cargotest-hwtracer/run/src/main.rs
+++ b/src/test/run-make/yk-cargotest-hwtracer/run/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Recent changes in rustc made `debug_context` an `Option` and there seems to be no guarantee that we will always have one. For example, this caused `rustc` to segfault when running `cargo test` (even on an empty project) with hardware tracing enabled.

Since there is nothing we can do if there is no debug context, we simply disable labels which means we won't be able to trace that particular function/block. However, since this should happen very rarely, we should barely notice this.