### PR TITLE
Allow other modules to create SirLocs

### DIFF
--- a/src/libcore/yk_swt.rs
+++ b/src/libcore/yk_swt.rs
@@ -21,6 +21,16 @@ pub struct SirLoc {
 }
 
 impl SirLoc {
+
+    /// Creates a new SirLoc.
+    pub fn new(crate_hash: u64, def_idx: u32, bb_idx: u32) -> SirLoc {
+        SirLoc {
+            crate_hash,
+            def_idx,
+            bb_idx
+        }
+    }
+
     /// Returns the crate hash of the location.
     pub fn crate_hash(&self) -> u64 {
         self.crate_hash


### PR DESCRIPTION
**Requires rebase after merging #71**

This PR allows us to create `SirLoc`s from within other modules which we will need to do when we add hardware tracing to `yktrace`.