### PR TITLE
Add a tracermode attribute

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1591,6 +1591,17 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     if sess.opts.crate_types.contains(&CrateType::ProcMacro) {
         ret.insert((sym::proc_macro, None));
     }
+    match sess.opts.cg.tracer {
+        TracerMode::Software => {
+            ret.insert((Symbol::intern("tracermode"), Some(Symbol::intern("sw"))));
+        },
+        TracerMode::Hardware => {
+            ret.insert((Symbol::intern("tracermode"), Some(Symbol::intern("hw"))));
+        },
+        TracerMode::Off => {
+            ret.insert((Symbol::intern("tracermode"), Some(Symbol::intern("off"))));
+        }
+    }
     ret
 }
 

--- a/src/test/run-make/yk-tracer-attrs/Makefile
+++ b/src/test/run-make/yk-tracer-attrs/Makefile
@@ -1,0 +1,9 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) -C tracer=sw sw.rs -o sw
+	./sw
+	$(RUSTC) -C tracer=hw hw.rs -o hw
+	./hw
+	$(RUSTC) -C tracer=off off.rs -o off
+	./off

--- a/src/test/run-make/yk-tracer-attrs/hw.rs
+++ b/src/test/run-make/yk-tracer-attrs/hw.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(tracermode="hw"))]
+    assert!(false)
+}

--- a/src/test/run-make/yk-tracer-attrs/off.rs
+++ b/src/test/run-make/yk-tracer-attrs/off.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(tracermode="off"))]
+    assert!(false)
+}

--- a/src/test/run-make/yk-tracer-attrs/sw.rs
+++ b/src/test/run-make/yk-tracer-attrs/sw.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(tracermode="sw"))]
+    assert!(false)
+}


### PR DESCRIPTION
This allows us to deactivate specific tests depending on which
tracermode is currently enabled.