### PR TITLE
Cache the results of the monomorphisation call resolver

### DIFF
--- a/src/librustc_yk_sections/Cargo.toml
+++ b/src/librustc_yk_sections/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 [dependencies]
 rustc = { path = "../librustc" }
 rustc_yk_link = { path = "../librustc_yk_link" }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { git = "https://github.com/vext01/yk", rev = "b4da4c7d08661b38f265fe072f88d354a2c4c8fa" }
 rustc_index = { path = "../librustc_index" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_data_structures = { path = "../librustc_data_structures" }


### PR DESCRIPTION
To cut a long story short, in order to determine static call targets
(where possible) it is necessary to call Instance::resolve(). However,
only the monomorphisation stage is permitted to do so.

This change caches the results of resolutions so that we can use them
during SIR lowering.

We also utilise the new `CallOperand::Virtual` variant for calls which
cannot be statically known at compile time.

Discussion here:
https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Calls.20in.20MIR

Companion to https://github.com/softdevteam/yk/pull/40