### PR TITLE
Keep track of positions of each builder in sir_cx.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5523,7 +5523,7 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#0428decc5c1cad2fd7f9b7236282e23a8e95bd13"
+source = "git+https://github.com/softdevteam/yk#7b4cfe28cf0148813ee8efd9b58c3c023321eafd"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -155,6 +155,7 @@ pub fn compile_codegen_unit(
             }
 
             if cx.has_debug() {
+                let mut labels = Vec::new();
                 if let Some(sir_cx) = cx.sir_cx.borrow_mut().as_mut() {
                     for (func_idx, blocks) in
                         sir_cx.funcs_and_blocks_deterministic().iter_enumerated()
@@ -192,11 +193,16 @@ pub fn compile_codegen_unit(
                                 bb_idx.index()
                             ))
                             .unwrap();
-                            let mut bx = Builder::with_cx(&cx);
-                            bx.position_at_end(llbb);
-                            bx.add_yk_block_label(llbb, lbl_name);
+                            labels.push((llbb, lbl_name));
                         }
                     }
+                }
+                // Only apply labels after collecting them in the previous step to avoid a double
+                // mutable borrow of sir_cx.
+                let mut bx = Builder::with_cx(&cx);
+                for (llbb, lbl_name) in labels {
+                    bx.position_at_end(llbb);
+                    bx.add_yk_block_label(llbb, lbl_name);
                 }
             }
 

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -916,6 +916,7 @@ extern "C" {
     pub fn LLVMIsAInstruction(Val: &Value) -> Option<&Value>;
     pub fn LLVMGetFirstBasicBlock(Fn: &Value) -> &BasicBlock;
     pub fn LLVMGetFirstInstruction(BB: &BasicBlock) -> Option<&Value>;
+    pub fn LLVMGetInstructionParent(I: &Value) -> &BasicBlock;
 
     // Operations on call sites
     pub fn LLVMSetInstructionCallConv(Instr: &Value, CC: c_uint);
@@ -1861,6 +1862,8 @@ extern "C" {
         Block: &BasicBlock,
         Name: *const c_char,
     );
+
+    pub fn LLVMRustInstructionIndex(Instr: &Value) -> usize;
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTypeToString(Type: &Type, s: &RustString);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1000,6 +1000,20 @@ extern "C" bool LLVMRustAddYkBlockLabel(LLVMBuilderRef Builder,
     return true;
 }
 
+extern "C" unsigned int LLVMRustInstructionIndex(LLVMValueRef Value) {
+    Instruction *Instr = unwrap<Instruction>(Value);
+    BasicBlock *B = Instr->getParent();
+    unsigned int index = 0;
+    for (BasicBlock::iterator I = B->begin(), IE = B->end(); I != IE; ++I) {
+        Instruction *CI = cast<Instruction>(I);
+        if (CI == Instr) {
+            break;
+        }
+        index++;
+    }
+    return index;
+}
+
 extern "C" void LLVMRustWriteTypeToString(LLVMTypeRef Ty, RustStringRef Str) {
   RawRustStringOstream OS(Str);
   unwrap<llvm::Type>(Ty)->print(OS);


### PR DESCRIPTION
> Requires https://github.com/softdevteam/yk/pull/44 to be merged first.

Whenever LLVM updates the position of a builder via
`LLVMPositionBuilderBefore` or `LLVMPositionBuilderAtEnd`, we need to
cache the basic block and index in sir_cx to allow us to insert
instructions at the correct position in the SIR blocks.