### PR TITLE
Start work on local variables and instructions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5523,7 +5523,6 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#7b4cfe28cf0148813ee8efd9b58c3c023321eafd"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.9"
 byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+#ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { path = "../../../yk/ykpack" }
 measureme = "0.7.1"
 rustc_session = { path = "../librustc_session" }

--- a/src/librustc/sir.rs
+++ b/src/librustc/sir.rs
@@ -48,6 +48,12 @@ newtype_index! {
     }
 }
 
+impl Into<ykpack::Local> for SirLocalIdx {
+    fn into(self) -> ykpack::Local {
+        ykpack::Local(self.as_u32())
+    }
+}
+
 /// Sir equivalents of LLVM values.
 #[derive(Debug)]
 pub enum SirValue {
@@ -235,7 +241,7 @@ impl SirCx {
         result: SirLocalIdx,
         rhs: ykpack::Rvalue,
     ) {
-        self.emit(builder, ykpack::Statement::Assign(result.as_u32(), rhs));
+        self.emit(builder, ykpack::Statement::Assign(result.into(), rhs));
     }
 
     pub fn emit_load(&mut self, builder: *const Builder, result: *const Value, arg: *const Value) {
@@ -246,7 +252,7 @@ impl SirCx {
         let res_local = self.get_or_add_local(func_idx, result).1;
         self.emit(
             builder,
-            ykpack::Statement::Assign(res_local.as_u32(), ykpack::Rvalue::Load(arg_local.as_u32())),
+            ykpack::Statement::Assign(res_local.into(), ykpack::Rvalue::Load(arg_local.as_u32())),
         );
     }
 

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -34,4 +34,5 @@ rustc_target = { path = "../librustc_target" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 syntax = { path = "../libsyntax" }
 rustc_span = { path = "../librustc_span" }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+#ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { path = "../../../yk/ykpack" }

--- a/src/librustc_codegen_llvm/mono_item.rs
+++ b/src/librustc_codegen_llvm/mono_item.rs
@@ -57,7 +57,7 @@ impl PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         // Set function flags in Yorick SIR.
         self.with_sir_cx_mut(|sir_cx| {
             let sir_lldecl = lldecl as *const llvm::Value as *const sir::Value;
-            let func_idx = sir_cx.llvm_values[&sir_lldecl].func_idx();
+            let func_idx = sir_cx.llvm_values[&sir_lldecl].func();
             let func = &mut sir_cx.funcs[func_idx];
             for attr in self.tcx.get_attrs(instance.def_id()).iter() {
                 if attr.check_name(sym::trace_head) {


### PR DESCRIPTION
I know @ptersilie is mostly away, so assigning @ltratt for code review, and @ptersilie for a brief "concept review" if he gets a moment.

**This is a draft. There is an unfinished ykpack change to come**

EDIT: Companion PR: https://github.com/softdevteam/yk/pull/46

Commit message follows:

Starting with store and load, as these are among the simplest.

Store instructions are simple, as they don't generate a value, but load
requires a little leg-work:

The way LLVM API works, when an instruction which generates a result is
built, an implicit assignment is created behind the scenes.

For example, to emit a load from C, you'd do: `LLVMBuildLoad(x, "res")`,
where `x` is an LLVM pointer representing where to load from, and  "res"
is the name of the result. This is equivalent to an LLVM bitcode
statement `%res = load(%x)`. Put differently, each computation adds a
new local variable to the function you are emitting instructions into.

Further, the call to `LLVMBuildLoad` returns another LLVM pointer
representing the variable which will store the result of the load. To
use the result as an operand for a further computation, you'd pass the
this pointer as an argument to another API call.

E.g.
```
LLVMValueRef *a = LLVMBuildLoad(x, "a");
LLVMValueRef *b = LLVMBuildLoad(y, "y");
LLVMValueRef *c = LLVmBuildAdd(a, b, "c");
```

Note that each ValueRef in the above also identifies the instruction
which generates the value.

The upshot of all of this is that in order to build SIR instructions
from within the LLVM codegen we need to be able to identify the results
of SIR computations from LLVM ValueRef pointers.

To this end, we add a `Local` variant to `sir::Value` and when a `load`
instruction is emitted, we create a SIR load statement and a SIR local
variable for the result, but also cache the LLVM pointer.

This mechanism will be used for all instructions which generate a value,
not just for loads.

Future work: Currently every load operand is assumed to be a local
variable, but it could be something else, like a constant, or a static.