### PR TITLE
SIRv3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,6 +3645,7 @@ dependencies = [
  "serialize",
  "syntax",
  "tempfile",
+ "ykpack",
 ]
 
 [[package]]

--- a/src/librustc/sir.rs
+++ b/src/librustc/sir.rs
@@ -1,174 +1,114 @@
 //! Serialised Intermediate Representation (SIR).
 //!
-//! SIR is built in-memory during LLVM code-generation, and finally placed into a dedicated ELF
-//! section at link time.
+//! SIR is built in-memory during code-generation (in rustc_codegen_ssa), and finally placed
+//! into an ELF section at link time.
 
-use rustc_data_structures::fx::FxHashMap;
-use rustc_index::{newtype_index, vec::IndexVec};
+use crate::ty::{Instance, TyCtxt};
+use rustc::mir;
+use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_session::config::OutputType;
+use rustc_span::sym;
+use std::cell::RefCell;
+use std::convert::TryFrom;
 use std::default::Default;
-use std::io::{self, Write};
+use std::io;
 use ykpack;
 
-// Duplicates of LLVM types defined elsewhere, copied to avoid cyclic dependencies. Whereas the
-// LLVM backend expresses pointers to these using references, we use raw pointers so to as avoid
-// introducing lifetime parameters to the SirCx (and thus into TyCtxt and every place that uses
-// it).
-extern "C" {
-    pub type Value;
-}
-extern "C" {
-    pub type BasicBlock;
-}
-extern "C" {
-    pub type Builder;
+const BUILD_SCRIPT_CRATE: &str = "build_script_build";
+
+/// A collection of in-memory SIR data structures to be serialised.
+/// Each codegen unit builds one instance of this which is then merged into a "global" instance
+/// when the unit completes.
+#[derive(Default)]
+pub struct Sir {
+    pub funcs: RefCell<Vec<ykpack::Body>>,
 }
 
-newtype_index! {
-    pub struct SirFuncIdx {
-        DEBUG_FORMAT = "SirFuncIdx({})"
+impl Sir {
+    /// Returns `true` if we should collect SIR for the current crate.
+    pub fn is_required(tcx: TyCtxt<'_>) -> bool {
+        (tcx.sess.opts.cg.tracer.encode_sir()
+            || tcx.sess.opts.output_types.contains_key(&OutputType::YkSir))
+            && tcx.crate_name(LOCAL_CRATE).as_str() != BUILD_SCRIPT_CRATE
     }
-}
 
-// The index of a block within a function.
-// Note that these indices are not globally unique. For a globally unique block identifier, a
-// (SirFuncIdx, SirBlockIdx) pair must be used.
-newtype_index! {
-    pub struct SirBlockIdx {
-        DEBUG_FORMAT = "SirBlockIdx({})"
+    /// Returns true if there is nothing inside.
+    pub fn is_empty(&self) -> bool {
+        self.funcs.borrow().len() == 0
     }
-}
 
-/// Sir equivalents of LLVM values.
-#[derive(Debug)]
-pub enum SirValue {
-    Func(SirFuncIdx),
-}
-
-impl SirValue {
-    pub fn func_idx(&self) -> SirFuncIdx {
-        let Self::Func(idx) = self;
-        *idx
+    /// Merges the SIR in `other` into `self`, consuming `other`.
+    pub fn update(&self, other: Self) {
+        self.funcs.borrow_mut().extend(other.funcs.into_inner());
     }
-}
 
-pub struct SirCx {
-    /// Maps an opaque LLVM `Value` to its SIR equivalent.
-    pub llvm_values: FxHashMap<*const Value, SirValue>,
-    /// Maps an opaque LLVM `BasicBlock` to the function and block index of its SIR equivalent.
-    pub llvm_blocks: FxHashMap<*const BasicBlock, (SirFuncIdx, SirBlockIdx)>,
-    /// Function store. Also owns the blocks
-    pub funcs: IndexVec<SirFuncIdx, ykpack::Body>,
-    /// Mirrors the insertion point for each LLVM `IrBuilder`.
-    pub builders: FxHashMap<*const Builder, (*const BasicBlock, usize)>,
-}
-
-impl SirCx {
-    pub fn new() -> Self {
-        Self {
-            llvm_values: Default::default(),
-            llvm_blocks: FxHashMap::default(),
-            funcs: Default::default(),
-            builders: Default::default(),
+    /// Writes a textual representation of the SIR to `w`. Used for `--emit yk-sir`.
+    pub fn dump(&self, tcx: TyCtxt<'_>, w: &mut dyn io::Write) -> Result<(), io::Error> {
+        for f in tcx.sir.funcs.borrow().iter() {
+            writeln!(w, "{}", f)?;
         }
-    }
-
-    pub fn add_func(&mut self, value: *const Value, symbol_name: String) {
-        let idx = SirFuncIdx::from_usize(self.funcs.len());
-
-        self.funcs.push(ykpack::Body {
-            symbol_name,
-            blocks: Default::default(),
-            flags: 0, // Set later.
-        });
-        let existing = self.llvm_values.insert(value, SirValue::Func(idx));
-        // In theory, if a function is declared twice, then LLVM should return the same pointer
-        // each time (i.e. it updates the existing record). This doesn't seem to happen though, as
-        // proven by this assertion.
-        debug_assert!(existing.is_none());
-    }
-
-    pub fn add_block(&mut self, func: *const Value, block: *const BasicBlock) {
-        let func_idx = self.llvm_values[&func].func_idx();
-        let sir_func = &mut self.funcs[func_idx];
-        let block_idx = SirBlockIdx::from_usize(sir_func.blocks.len());
-        sir_func.blocks.push(ykpack::BasicBlock {
-            stmts: Default::default(),
-            term: ykpack::Terminator::Unreachable, // FIXME
-        });
-        let existing = self.llvm_blocks.insert(block, (func_idx, block_idx));
-        debug_assert!(existing.is_none());
-    }
-
-    pub fn get_symbol_name(&mut self, func: *const Value) -> &String {
-        let func_idx = self.llvm_values[&func].func_idx();
-        let sir_func = &mut self.funcs[func_idx];
-        &sir_func.symbol_name
-    }
-
-    /// For hardware tracing, during codegen we insert DILabels to know where we are in the binary.
-    /// These labels must be emitted in a deterministic order otherwise the reproducible build
-    /// checker gets upset. This function gives the codegen what it needs in a data structure which
-    /// can be iterated deterministically.
-    pub fn funcs_and_blocks_deterministic(
-        &self,
-    ) -> IndexVec<SirFuncIdx, IndexVec<SirBlockIdx, *const BasicBlock>> {
-        // We start with a data structure where all LLVM block pointers are unknown (None).
-        let mut res = IndexVec::from_elem_n(IndexVec::default(), self.funcs.len());
-        for (func_idx, func) in self.funcs.iter_enumerated() {
-            res[func_idx] = IndexVec::from_elem_n(None, func.blocks.len());
-        }
-
-        // Now we iterate over our hash table, replacing the aforementioned `None`s.
-        for (bb, (func_idx, bb_idx)) in &self.llvm_blocks {
-            debug_assert!(res[*func_idx][*bb_idx] == None);
-            res[*func_idx][*bb_idx] = Some(*bb);
-        }
-
-        // Now get rid of the Option wrappers around the pointers. The `unwrap()` is guaranteed to
-        // succeed, as the above loop mutates every single `None` to a `Some`.
-        let mut ret = IndexVec::default();
-        for func_blocks in res.into_iter() {
-            ret.push(func_blocks.into_iter().map(|b| b.unwrap()).collect());
-        }
-
-        ret
-    }
-
-    /// Dump SIR to text file.
-    /// Used in tests and for debugging.
-    pub fn dump(&self, dest: &mut dyn Write) -> Result<(), io::Error> {
-        for func in &self.funcs {
-            writeln!(dest, "{}", func)?;
-        }
-
         Ok(())
     }
+}
 
-    /// Given an llvm::BasicBlock returns the equivalent ykpack::BasicBlock in the SIR.
-    fn get_sir_block(&mut self, bb: *const BasicBlock) -> &mut ykpack::BasicBlock {
-        let (sirfuncidx, sirblockidx) = self.llvm_blocks[&bb];
-        let sir_func = &mut self.funcs[sirfuncidx];
-        &mut sir_func.blocks[sirblockidx.index()]
+/// A structure for building the SIR of a function.
+pub struct SirFuncCx {
+    pub func: ykpack::Body,
+}
+
+impl SirFuncCx {
+    pub fn new<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>, num_blocks: usize) -> Self {
+        let symbol_name = format!("new__{}", tcx.symbol_name(*instance).name.as_str());
+
+        let mut flags = 0;
+        for attr in tcx.get_attrs(instance.def_id()).iter() {
+            if attr.check_name(sym::trace_head) {
+                flags |= ykpack::bodyflags::TRACE_HEAD;
+            } else if attr.check_name(sym::trace_tail) {
+                flags |= ykpack::bodyflags::TRACE_TAIL;
+            }
+        }
+
+        // Since there's a one-to-one mapping between MIR and SIR blocks, we know how many SIR
+        // blocks we will need and can allocate empty SIR blocks ahead of time.
+        let blocks = vec![
+            ykpack::BasicBlock {
+                stmts: Default::default(),
+                term: ykpack::Terminator::Unreachable,
+            };
+            num_blocks
+        ];
+
+        Self { func: ykpack::Body { symbol_name, blocks, flags } }
     }
 
-    /// Set the current position of builder to `pos`. Equivalent to LLVMPositionBuilderBefore.
-    pub fn position_before(&mut self, builder: *const Builder, bb: *const BasicBlock, pos: usize) {
-        self.builders.insert(builder, (bb, pos));
+    /// Returns true if there are no basic blocks.
+    pub fn is_empty(&self) -> bool {
+        self.func.blocks.len() == 0
     }
 
-    /// Set the current position of builder to the end of `bb`. Equivalent to
-    /// LLVMPositionBuilderAtEnd.
-    pub fn position_at_end(&mut self, builder: *const Builder, bb: *const BasicBlock) {
-        let sir_block = self.get_sir_block(bb);
-        let pos = sir_block.stmts.len();
-        self.builders.insert(builder, (bb, pos));
+    /// Appends a statement to the specified basic block.
+    fn push_stmt(&mut self, bb: ykpack::BasicBlockIndex, stmt: ykpack::Statement) {
+        self.func.blocks[usize::try_from(bb).unwrap()].stmts.push(stmt);
     }
 
-    /// Create a return void instruction in the SIR.
-    pub fn ret_void(&mut self, builder: *const Builder) {
-        let (bb, idx) = self.builders[&builder];
-        let sir_block = self.get_sir_block(bb);
-        let instr = ykpack::Statement::Return;
-        sir_block.stmts.insert(idx, instr);
+    /// Sets the terminator of the specified block.
+    pub fn codegen_terminator(
+        &mut self,
+        bb: ykpack::BasicBlockIndex,
+        mir_term: &mir::Terminator<'_>,
+    ) {
+        let term = &mut self.func.blocks[usize::try_from(bb).unwrap()].term;
+        // We should only ever replace the default unreachable terminator assigned at allocation time.
+        debug_assert!(*term == ykpack::Terminator::Unreachable);
+
+        // FIXME: Nothing is implemented yet.
+        *term = ykpack::Terminator::Unimplemented(format!("{:?}", mir_term.kind));
+    }
+
+    /// Converts a MIR statement to SIR, appending the result to `bb`.
+    pub fn codegen_statement(&mut self, bb: ykpack::BasicBlockIndex, stmt: &mir::Statement<'_>) {
+        // FIXME: Nothing is implemented yet.
+        self.push_stmt(bb, ykpack::Statement::Unimplemented(format!("{:?}", stmt)));
     }
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -20,7 +20,7 @@ use crate::mir::interpret::{Allocation, ConstValue, Scalar};
 use crate::mir::{
     interpret, BodyAndCache, Field, Local, Place, PlaceElem, ProjectionKind, Promoted,
 };
-use crate::sir::SirCx;
+use crate::sir::Sir;
 use crate::traits;
 use crate::traits::{Clause, Clauses, Goal, GoalKind, Goals};
 use crate::ty::free_region_map::FreeRegionMap;
@@ -73,7 +73,6 @@ use syntax::node_id::NodeMap;
 use smallvec::SmallVec;
 use std::any::Any;
 use std::borrow::Borrow;
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::hash_map::{self, Entry};
 use std::fmt;
@@ -1025,8 +1024,8 @@ pub struct GlobalCtxt<'tcx> {
 
     output_filenames: Arc<OutputFilenames>,
 
-    /// As each codegen unit completes, it copies the SIR here for serialisation later.
-    pub finished_sir_cxs: RefCell<Vec<SirCx>>,
+    /// Yorick seriliased IR.
+    pub sir: Sir,
 }
 
 impl<'tcx> TyCtxt<'tcx> {
@@ -1221,7 +1220,7 @@ impl<'tcx> TyCtxt<'tcx> {
             allocation_interner: Default::default(),
             alloc_map: Lock::new(interpret::AllocMap::new()),
             output_filenames: Arc::new(output_filenames.clone()),
-            finished_sir_cxs: RefCell::new(Vec::new()),
+            sir: Default::default(),
         }
     }
 

--- a/src/librustc_codegen_llvm/declare.rs
+++ b/src/librustc_codegen_llvm/declare.rs
@@ -19,7 +19,6 @@ use crate::llvm::AttributePlace::Function;
 use crate::type_::Type;
 use crate::value::Value;
 use log::debug;
-use rustc::sir;
 use rustc::ty::Ty;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -37,13 +36,6 @@ fn declare_raw_fn(
     debug!("declare_raw_fn(name={:?}, ty={:?})", name, ty);
     let namebuf = SmallCStr::new(name);
     let llfn = unsafe { llvm::LLVMRustGetOrInsertFunction(cx.llmod, namebuf.as_ptr(), ty) };
-
-    cx.with_sir_cx_mut(|sir_cx| {
-        sir_cx.add_func(
-            llfn as *const llvm::Value as *const sir::Value,
-            String::from(namebuf.as_c_str().to_str().unwrap()),
-        )
-    });
 
     llvm::SetFunctionCallConv(llfn, callconv);
     // Function addresses in Rust are never significant, allowing functions to

--- a/src/librustc_codegen_llvm/sir.rs
+++ b/src/librustc_codegen_llvm/sir.rs
@@ -28,20 +28,12 @@ const SIR_GLOBAL_SYM_PREFIX: &str = ".yksir";
 /// Writes the SIR into a buffer which will be linked in into an ELF section via LLVM.
 /// This is based on write_compressed_metadata().
 pub fn write_sir<'tcx>(tcx: TyCtxt<'tcx>, sir_llvm_module: &mut ModuleLlvm) {
-    let sir_cxs = tcx.finished_sir_cxs.replace(Vec::new());
+    let sir_funcs = tcx.sir.funcs.replace(Vec::new());
     let mut buf = Vec::new();
     let mut encoder = ykpack::Encoder::from(&mut buf);
 
-    for sir_cx in sir_cxs.into_iter() {
-        for func in sir_cx.funcs {
-            // Often there are function declarations with no blocks. I think these are call
-            // targets from other crates or compilation units, which have to be declared to
-            // keep LLVM happy. There's no use in serialising these "empty functions" and they
-            // clash with the real declarations.
-            if !func.blocks.is_empty() {
-                encoder.serialise(ykpack::Pack::Body(func)).unwrap();
-            }
-        }
+    for func in sir_funcs {
+        encoder.serialise(ykpack::Pack::Body(func)).unwrap();
     }
 
     encoder.done().unwrap();

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -34,3 +34,4 @@ rustc_incremental = { path = "../librustc_incremental" }
 rustc_index = { path = "../librustc_index" }
 rustc_target = { path = "../librustc_target" }
 rustc_session = { path = "../librustc_session" }
+ykpack = { git = "https://github.com/softdevteam/yk" }

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -716,9 +716,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
 
     // If we generated Sir and we are not dumping it textually, then encode it into an LLVM module
     // for later linkage.
-    if !tcx.sess.opts.output_types.contains_key(&OutputType::YkSir)
-        && !tcx.finished_sir_cxs.borrow().is_empty()
-    {
+    if !tcx.sess.opts.output_types.contains_key(&OutputType::YkSir) && !tcx.sir.is_empty() {
         let sir_cgu_name =
             cgu_name_builder.build_cgu_name(LOCAL_CRATE, &["crate"], Some("yksir")).to_string();
         let mut sir_module = backend.new_metadata(tcx, &sir_cgu_name);

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -8,7 +8,12 @@ use crate::traits::BuilderMethods;
 use crate::traits::*;
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
-    pub fn codegen_statement(&mut self, mut bx: Bx, statement: &mir::Statement<'tcx>) -> Bx {
+    pub fn codegen_statement(
+        &mut self,
+        mut bx: Bx,
+        _bb: mir::BasicBlock,
+        statement: &mir::Statement<'tcx>,
+    ) -> Bx {
         debug!("codegen_statement(statement={:?})", statement);
 
         self.set_debug_loc(&mut bx, statement.source_info);

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -13,10 +13,9 @@ use crate::mir::place::PlaceRef;
 use crate::MemFlags;
 
 use rustc::ty::layout::{Align, HasParamEnv, Size};
-use rustc::ty::Ty;
+use rustc::ty::{SymbolName, Ty};
 use rustc_target::spec::HasTargetSpec;
 
-use std::ffi::CString;
 use std::iter::TrustedLen;
 use std::ops::Range;
 
@@ -45,7 +44,7 @@ pub trait BuilderMethods<'a, 'tcx>:
     fn llbb(&self) -> Self::BasicBlock;
 
     fn first_instruction(&mut self, llbb: Self::BasicBlock) -> Option<Self::Value>;
-    fn add_yk_block_label(&mut self, block: Self::BasicBlock, lbl_name: CString);
+    fn add_yk_block_label(&mut self, fname: &str, sym: &SymbolName, bbidx: usize);
     fn position_before(&mut self, instr: Self::Value);
     fn position_at_end(&mut self, llbb: Self::BasicBlock);
     fn ret_void(&mut self);

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -1,7 +1,7 @@
 use super::BackendTypes;
 use rustc::mir::mono::CodegenUnit;
 use rustc::session::Session;
-use rustc::sir::SirCx;
+use rustc::sir::SirFuncCx;
 use rustc::ty::{self, Instance, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use std::cell::RefCell;
@@ -22,7 +22,5 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn set_frame_pointer_elimination(&self, llfn: Self::Function);
     fn apply_target_cpu_attr(&self, llfn: Self::Function);
     fn create_used_variable(&self);
-    fn with_sir_cx_mut<F>(&self, f: F)
-    where
-        F: Fn(&mut SirCx);
+    fn push_sir_func(&self, func_cx: SirFuncCx);
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -979,16 +979,10 @@ extern "C" int64_t LLVMRustDIBuilderCreateOpPlusUconst() {
 extern "C" bool LLVMRustAddYkBlockLabel(LLVMBuilderRef Builder,
         LLVMRustDIBuilderRef DBuilder, LLVMBasicBlockRef Block, char *Name) {
 
-    // Use C++ call FIXME
     BasicBlock *B = unwrap(Block);
     Function *f = B->getParent();
     DISubprogram *SP = f->getSubprogram();
     auto Loc = DebugLoc::get(0, 0, SP);
-    if (B->isLandingPad()) {
-        // FIXME We may want to add labels to the landingpad instruction
-        // (getLandingPadInst) here in the future.
-        return false;
-    }
     auto First = B->getFirstNonPHI();
     if (First == nullptr) {
         // There is no instruction to attach a label to, so bail out.

--- a/src/test/run-make/yk-cargotest-hwtracer/Makefile
+++ b/src/test/run-make/yk-cargotest-hwtracer/Makefile
@@ -3,4 +3,5 @@
 export RUSTC := $(RUSTC_ORIGINAL)
 
 all:
+	cd run && $$CARGO clean
 	cd run && [ "`RUSTFLAGS='-C tracer=hw' $$CARGO test | grep 'result: ok' | wc -l `" -eq 1 ]


### PR DESCRIPTION
This change moves SIR generation from `librustc_codegen_llvm` to
`librustc_codegen_ssa`.

This means that SIR will be generated from *monomorphised* MIR, rather
than from LLVM API calls. This is easier to implement and makes it
easier to access high-level program information, but means that our
notion of a block is a little further away from what ends up in the
binary. We've discussed this and think that it probably isn't going to
be an issue.

For now all SIR statements and terminators are dummy "unimplemented"
place-holders. Next we will start serialising them properly.

Co-authored-by: @ptersilie 