### PR TITLE
Lower MIR call terminators to their SIR equivalent.

### DIFF
--- a/src/librustc/sir.rs
+++ b/src/librustc/sir.rs
@@ -93,17 +93,11 @@ impl SirFuncCx {
     }
 
     /// Sets the terminator of the specified block.
-    pub fn codegen_terminator(
-        &mut self,
-        bb: ykpack::BasicBlockIndex,
-        mir_term: &mir::Terminator<'_>,
-    ) {
+    pub fn set_terminator(&mut self, bb: ykpack::BasicBlockIndex, new_term: ykpack::Terminator) {
         let term = &mut self.func.blocks[usize::try_from(bb).unwrap()].term;
         // We should only ever replace the default unreachable terminator assigned at allocation time.
         debug_assert!(*term == ykpack::Terminator::Unreachable);
-
-        // FIXME: Nothing is implemented yet.
-        *term = ykpack::Terminator::Unimplemented(format!("{:?}", mir_term.kind));
+        *term = new_term
     }
 
     /// Converts a MIR statement to SIR, appending the result to `bb`.


### PR DESCRIPTION
The target function must be monomorphised. We had two options:

 - Duplicate monomorphisation logic in codegen_block().

 - Lower terminators deeper in the codegen and reuse existing
   monomorphisation logic.

I don't like the idea of having to keep monomorphisation logic in-sync
with upstream, so I've opted for the latter. This strategy means we now
have lots of places where we have to lower a terminator, whereas before
we had only one.

I can live with this, however I did add a macro to help us identify the
many (currently) unimplemented terminator insertions.