### PR TITLE
Revert "Use the abort strategy when tracing."

### DIFF
--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -11,7 +11,7 @@ use crate::{early_error, early_warn, Session};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::impl_stable_hash_via_hash;
 
-use rustc_target::spec::{PanicStrategy, Target, TargetTriple};
+use rustc_target::spec::{Target, TargetTriple};
 
 use crate::parse::CrateConfig;
 use rustc_feature::UnstableFeatures;
@@ -1752,12 +1752,6 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     // reorder things, thus destroying the correctness of our SIR and DILabels.
     if opt_level != OptLevel::No && cg.tracer != TracerMode::Off {
         early_error(error_format, &format!("optimisation cannot be enabled with a tracer"));
-    }
-
-    // If a tracer is enabled, we use only the abort panic strategy.
-    if cg.tracer != TracerMode::Off {
-        cg.panic = Some(PanicStrategy::Abort);
-        debugging_opts.panic_abort_tests = true;
     }
 
     let cg = cg;

--- a/src/test/run-make/yk-abort-strategy-std/Makefile
+++ b/src/test/run-make/yk-abort-strategy-std/Makefile
@@ -1,7 +1,0 @@
--include ../../run-make-fulldeps/tools.mk
-
-PROG=yk-abort-strategy-std
-
-all:
-	$(RUSTC) --emit mir ${PROG}.rs && grep 'resume;' ${TMPDIR}/${PROG}.mir
-	$(RUSTC) --emit mir -C tracer=hw ${PROG}.rs && grep 'resume;' ${TMPDIR}/${PROG}.mir; [ $$? -eq 1 ]

--- a/src/test/run-make/yk-abort-strategy-std/yk-abort-strategy-std.rs
+++ b/src/test/run-make/yk-abort-strategy-std/yk-abort-strategy-std.rs
@@ -1,9 +1,0 @@
-fn main() {
-    println!("{}", f(None));
-}
-
-#[inline(never)]
-fn f(a: Option<usize>) -> String {
-    let s = String::from("hello");
-    format!("{}{}", s, a.unwrap())
-}

--- a/src/test/run-make/yk-abort-strategy/Makefile
+++ b/src/test/run-make/yk-abort-strategy/Makefile
@@ -1,7 +1,0 @@
--include ../../run-make-fulldeps/tools.mk
-
-PROG=yk-abort-strategy
-
-all:
-	$(RUSTC) --emit mir ${PROG}.rs && grep 'resume;' ${TMPDIR}/${PROG}.mir
-	$(RUSTC) --emit mir -C tracer=hw ${PROG}.rs && grep 'resume;' ${TMPDIR}/${PROG}.mir; [ $$? -eq 1 ]

--- a/src/test/run-make/yk-abort-strategy/yk-abort-strategy.rs
+++ b/src/test/run-make/yk-abort-strategy/yk-abort-strategy.rs
@@ -1,9 +1,0 @@
-fn main() {
-    let s = String::from("hello");
-    println!("{} {}", s, f(1));
-}
-
-#[inline(never)]
-fn f(_a: usize) -> usize {
-    panic!();
-}


### PR DESCRIPTION
This reverts commit c8c964ad78da004d534a7e05d931a114f966fd77.

The reason for this is that benchmark tests require the unwind strategy and
since benchmarks are mixed with normal tests in the same binary, it means that
all of our tests would have to use the unwind strategy.

See:
https://github.com/softdevteam/yk/pull/49#issuecomment-598806879