### PR TITLE
Generate Call terminators with a return value and arguments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5524,7 +5524,7 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#141aa78d20a082f2518b56bc57181dbce84ce2f0"
+source = "git+https://github.com/vext01/yk?rev=dde95dd15e714f4d676f77f564488aadc9d263da#dde95dd15e714f4d676f77f564488aadc9d263da"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -37,6 +37,6 @@ parking_lot = "0.9"
 byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { git = "https://github.com/vext01/yk", rev = "dde95dd15e714f4d676f77f564488aadc9d263da" }
 measureme = "0.7.1"
 rustc_session = { path = "../librustc_session" }

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -34,4 +34,4 @@ rustc_target = { path = "../librustc_target" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 syntax = { path = "../libsyntax" }
 rustc_span = { path = "../librustc_span" }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { git = "https://github.com/vext01/yk", rev = "dde95dd15e714f4d676f77f564488aadc9d263da" }

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -34,4 +34,4 @@ rustc_incremental = { path = "../librustc_incremental" }
 rustc_index = { path = "../librustc_index" }
 rustc_target = { path = "../librustc_target" }
 rustc_session = { path = "../librustc_session" }
-ykpack = { git = "https://github.com/softdevteam/yk" }
+ykpack = { git = "https://github.com/vext01/yk", rev = "dde95dd15e714f4d676f77f564488aadc9d263da" }

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -484,7 +484,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 bb.as_u32(),
                 ykpack::Terminator::Call {
                     operand: sir_opnd,
-                    ret_bb: destination.map(|d| d.1.as_u32()),
+                    args: args.iter().map(|a| sfcx.lower_operand(a)).collect(),
+                    destination: destination
+                        .map(|(ret_val, ret_bb)| (sfcx.lower_place(&ret_val), ret_bb.as_u32())),
                 },
             );
         }


### PR DESCRIPTION
Includes a fair amount of churn due to necessary ykpack changes and for
modularity.

E.g. Make lower_place() return ykpack::Place, not ykpack::Local.

Companion PR:
https://github.com/softdevteam/yk/pull/50

We will need a 3-stage merge.