### PR TITLE
Update lock file due to changes in yk.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5568,7 +5568,7 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#a9943f67746dcedea6f414f9694ba77bd7e6868f"
+source = "git+https://github.com/softdevteam/yk#9c227f0b2b89905b18f8e10d636f3925eaf455ac"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",


### PR DESCRIPTION
I was getting deserialisation errors. Took me a while to figure out what had happened.

Because we no-longer do 3-phase merges, we have no inherent lock file syncing. So we have to do it manually.

Here's one which fixes my derserialisation problem.