### PR TITLE
Pass `--export-dynamic` to the linker to expose all symbols at runtime.

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1312,11 +1312,17 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
     // Try to strip as much out of the generated object by removing unused
     // sections if possible. See more comments in linker.rs
     //
-    // In the eyes of the compiler, SIR (and Rust metadata) are unreferenced and will be removed it
+    // In the eyes of the compiler, SIR (and Rust metadata) are unreferenced and will be removed if
     // we don't omit section garbage collection.
     if !sess.opts.cg.link_dead_code && sess.opts.cg.tracer == TracerMode::Off {
         let keep_metadata = crate_type == config::CrateType::Dylib;
         cmd.gc_sections(keep_metadata);
+    }
+
+    // When tracing, export all symbols so we can use dlsym(3).
+    // Without this, only symbols in shared objects would be available.
+    if sess.opts.cg.tracer != TracerMode::Off {
+        cmd.export_dynamic();
     }
 
     let used_link_args = &codegen_results.crate_info.link_args;

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -117,6 +117,7 @@ pub trait Linker {
     fn group_start(&mut self);
     fn group_end(&mut self);
     fn linker_plugin_lto(&mut self);
+    fn export_dynamic(&mut self);
     // Should have been finalize(self), but we don't support self-by-value on trait objects (yet?).
     fn finalize(&mut self) -> Command;
 }
@@ -536,6 +537,10 @@ impl<'a> Linker for GccLinker<'a> {
             }
         }
     }
+
+    fn export_dynamic(&mut self) {
+        self.linker_arg("--export-dynamic");
+    }
 }
 
 pub struct MsvcLinker<'a> {
@@ -769,6 +774,10 @@ impl<'a> Linker for MsvcLinker<'a> {
     fn linker_plugin_lto(&mut self) {
         // Do nothing
     }
+
+    fn export_dynamic(&mut self) {
+        todo!("export-dynamic");
+    }
 }
 
 pub struct EmLinker<'a> {
@@ -938,6 +947,10 @@ impl<'a> Linker for EmLinker<'a> {
 
     fn linker_plugin_lto(&mut self) {
         // Do nothing
+    }
+
+    fn export_dynamic(&mut self) {
+        todo!("export-dynamic");
     }
 }
 
@@ -1109,6 +1122,10 @@ impl<'a> Linker for WasmLd<'a> {
     fn linker_plugin_lto(&mut self) {
         // Do nothing for now
     }
+
+    fn export_dynamic(&mut self) {
+        todo!("export-dynamic");
+    }
 }
 
 fn exported_symbols(tcx: TyCtxt<'_>, crate_type: CrateType) -> Vec<String> {
@@ -1267,4 +1284,8 @@ impl<'a> Linker for PtxLinker<'a> {
     fn group_end(&mut self) {}
 
     fn linker_plugin_lto(&mut self) {}
+
+    fn export_dynamic(&mut self) {
+        todo!("export-dynamic");
+    }
 }


### PR DESCRIPTION
By default only symbols in shared objects (i.e. not the main code
object) would be exposed.

We need this to be able to call symbols from within traces.