### PR TITLE
Implement basic projection lowering.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#7a75f4c69346043a7a1ce088c8047080ed023b1e"
+source = "git+https://github.com/softdevteam/yk#c2b9d9091cb4df330e804a5c4a383cc162ce7d44"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,8 @@ rustc-std-workspace-std = { path = 'src/tools/rustc-std-workspace-std' }
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
 
-# When developing Yorick, you may find that you need to override ykpack.
-# You can do it once here, instead of all over the place.
+# When developing Yorick, you may find that you need to override ykpack. You
+# can do it once here, instead of all over the place, by uncommenting the
+# following two lines.
 #[patch."https://github.com/softdevteam/yk"]
 #ykpack = { path = "../yk/ykpack" }

--- a/src/librustc_middle/sir.rs
+++ b/src/librustc_middle/sir.rs
@@ -183,11 +183,14 @@ impl SirFuncCx<'tcx> {
         ykpack::Place {
             local: self.lower_local(place.local),
             // FIXME projections not yet implemented.
-            projection: place
-                .projection
-                .iter()
-                .map(|p| ykpack::PlaceElem::Unimplemented(format!("{:?}", p)))
-                .collect(),
+            projection: place.projection.iter().map(|p| self.lower_projection(&p)).collect(),
+        }
+    }
+
+    pub fn lower_projection(&self, pe: &mir::PlaceElem<'_>) -> ykpack::Projection {
+        match pe {
+            mir::ProjectionElem::Field(field, ..) => ykpack::Projection::Field(field.as_u32()),
+            _ => ykpack::Projection::Unimplemented(format!("{:?}", pe)),
         }
     }
 


### PR DESCRIPTION
This PR adds lowering for projections. This is currently a very basic version. For proper projections (which we'll do later) we need to do a bit more work. But this will allow us to move forward with trace inputs.

Companion PR coming soon (once https://github.com/softdevteam/yk/pull/82 is merged).