### PR TITLE
Type code tidying.

### DIFF
--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -40,6 +40,7 @@ pub mod glue;
 pub mod meth;
 pub mod mir;
 pub mod mono_item;
+pub mod sir;
 pub mod traits;
 
 pub struct ModuleCodegen<M> {

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -261,7 +261,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     if fx.sir_func_cx.is_some() {
         let mut decls: Vec<ykpack::LocalDecl> = Vec::new();
         for l in &fx.locals {
-            decls.push(sir::lower_local_ref(cx.tcx(), &bx, &fx, l));
+            decls.push(sir::lower_local_ref(cx.tcx(), &bx, l));
         }
         fx.sir_func_cx.as_mut().unwrap().func.local_decls.extend(decls);
     }

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -1,13 +1,11 @@
 use crate::base;
 use crate::traits::*;
 use rustc_errors::ErrorReported;
-use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::layout::{FnAbiExt, HasTyCtxt, TyAndLayout};
-use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, Instance, Ty, TypeFoldable};
 use rustc_target::abi::call::{FnAbi, PassMode};
-use rustc_target::abi::FieldsShape;
 
 use std::iter;
 
@@ -17,9 +15,9 @@ use rustc_index::vec::IndexVec;
 use self::analyze::CleanupKind;
 use self::debuginfo::{FunctionDebugContext, PerLocalVarDebugInfo};
 use self::place::PlaceRef;
+use crate::sir;
 use rustc_middle::mir::traversal;
 use rustc_middle::sir::{Sir, SirFuncCx};
-use std::convert::TryFrom;
 
 use self::operand::{OperandRef, OperandValue};
 
@@ -114,7 +112,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 }
 
-enum LocalRef<'tcx, V> {
+pub(crate) enum LocalRef<'tcx, V> {
     Place(PlaceRef<'tcx, V>),
     /// `UnsizedPlace(p)`: `p` itself is a thin pointer (indirect place).
     /// `*p` is the fat pointer that references the actual unsized place.
@@ -263,7 +261,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     if fx.sir_func_cx.is_some() {
         let mut decls: Vec<ykpack::LocalDecl> = Vec::new();
         for l in &fx.locals {
-            decls.push(lower_local_ref(cx.tcx(), &bx, &fx, l));
+            decls.push(sir::lower_local_ref(cx.tcx(), &bx, &fx, l));
         }
         fx.sir_func_cx.as_mut().unwrap().func.local_decls.extend(decls);
     }
@@ -524,94 +522,3 @@ pub mod operand;
 pub mod place;
 mod rvalue;
 mod statement;
-
-// FIXME move the following code to librustc_middle/sir.rs (as a method or SirFuncCx if possible).
-use rustc_middle::ty::AdtDef;
-use rustc_target::abi::VariantIdx;
-
-fn lower_local_ref<'a, 'l, 'tcx, Bx: BuilderMethods<'a, 'tcx>, V>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    fx: &FunctionCx<'a, 'tcx, Bx>,
-    decl: &'l LocalRef<'tcx, V>,
-) -> ykpack::LocalDecl {
-    let ty_layout = match decl {
-        LocalRef::Place(pref) => pref.layout,
-        LocalRef::UnsizedPlace(..) => {
-            let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::UnsizedPlace"));
-            return ykpack::LocalDecl {
-                ty: (
-                    tcx.crate_hash(LOCAL_CRATE).as_u64(),
-                    tcx.sir_types.borrow_mut().index(sir_ty),
-                ),
-            };
-        }
-        LocalRef::Operand(opt_oref) => {
-            if let Some(oref) = opt_oref {
-                oref.layout
-            } else {
-                let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::OperandRef is None"));
-                return ykpack::LocalDecl {
-                    ty: (
-                        tcx.crate_hash(LOCAL_CRATE).as_u64(),
-                        tcx.sir_types.borrow_mut().index(sir_ty),
-                    ),
-                };
-            }
-        }
-    };
-
-    ykpack::LocalDecl { ty: lower_ty_and_layout(tcx, bx, fx, &ty_layout) }
-}
-
-fn lower_ty_and_layout<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    fx: &FunctionCx<'a, 'tcx, Bx>,
-    ty_layout: &TyAndLayout<'tcx>,
-) -> ykpack::TypeId {
-    let sir_ty = match ty_layout.ty.kind {
-        ty::Adt(adt_def, ..) => lower_adt(tcx, bx, fx, adt_def, &ty_layout),
-        _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
-    };
-
-    (tcx.crate_hash(LOCAL_CRATE).as_u64(), tcx.sir_types.borrow_mut().index(sir_ty))
-}
-
-fn lower_adt<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    fx: &FunctionCx<'a, 'tcx, Bx>,
-    adt_def: &AdtDef,
-    ty_layout: &TyAndLayout<'tcx>,
-) -> ykpack::Ty {
-    let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
-    let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
-
-    if adt_def.variants.len() == 1 {
-        // Plain old struct-like thing.
-        let struct_layout = ty_layout.for_variant(bx, VariantIdx::from_u32(0));
-
-        match &ty_layout.fields {
-            FieldsShape::Arbitrary { offsets, .. } => {
-                let mut sir_offsets = Vec::new();
-                let mut sir_tys = Vec::new();
-                for (idx, offs) in offsets.iter().enumerate() {
-                    sir_tys.push(lower_ty_and_layout(tcx, bx, fx, &struct_layout.field(bx, idx)));
-                    sir_offsets.push(offs.bytes());
-                }
-
-                ykpack::Ty::Struct(ykpack::StructTy {
-                    offsets: sir_offsets,
-                    align,
-                    size,
-                    tys: sir_tys,
-                })
-            }
-            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
-        }
-    } else {
-        // An enum with variants.
-        ykpack::Ty::Unimplemented(format!("{:?}", ty_layout))
-    }
-}

--- a/src/librustc_codegen_ssa/sir.rs
+++ b/src/librustc_codegen_ssa/sir.rs
@@ -1,0 +1,95 @@
+use crate::mir::{FunctionCx, LocalRef};
+use crate::traits::BuilderMethods;
+use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_middle::ty::AdtDef;
+use rustc_middle::ty::{self, layout::TyAndLayout, TyCtxt};
+use rustc_target::abi::FieldsShape;
+use rustc_target::abi::VariantIdx;
+use std::convert::TryFrom;
+
+pub(crate) fn lower_local_ref<'a, 'l, 'tcx, Bx: BuilderMethods<'a, 'tcx>, V>(
+    tcx: TyCtxt<'tcx>,
+    bx: &Bx,
+    fx: &FunctionCx<'a, 'tcx, Bx>,
+    decl: &'l LocalRef<'tcx, V>,
+) -> ykpack::LocalDecl {
+    let ty_layout = match decl {
+        LocalRef::Place(pref) => pref.layout,
+        LocalRef::UnsizedPlace(..) => {
+            let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::UnsizedPlace"));
+            return ykpack::LocalDecl {
+                ty: (
+                    tcx.crate_hash(LOCAL_CRATE).as_u64(),
+                    tcx.sir_types.borrow_mut().index(sir_ty),
+                ),
+            };
+        }
+        LocalRef::Operand(opt_oref) => {
+            if let Some(oref) = opt_oref {
+                oref.layout
+            } else {
+                let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::OperandRef is None"));
+                return ykpack::LocalDecl {
+                    ty: (
+                        tcx.crate_hash(LOCAL_CRATE).as_u64(),
+                        tcx.sir_types.borrow_mut().index(sir_ty),
+                    ),
+                };
+            }
+        }
+    };
+
+    ykpack::LocalDecl { ty: lower_ty_and_layout(tcx, bx, fx, &ty_layout) }
+}
+
+fn lower_ty_and_layout<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+    tcx: TyCtxt<'tcx>,
+    bx: &Bx,
+    fx: &FunctionCx<'a, 'tcx, Bx>,
+    ty_layout: &TyAndLayout<'tcx>,
+) -> ykpack::TypeId {
+    let sir_ty = match ty_layout.ty.kind {
+        ty::Adt(adt_def, ..) => lower_adt(tcx, bx, fx, adt_def, &ty_layout),
+        _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
+    };
+
+    (tcx.crate_hash(LOCAL_CRATE).as_u64(), tcx.sir_types.borrow_mut().index(sir_ty))
+}
+
+fn lower_adt<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+    tcx: TyCtxt<'tcx>,
+    bx: &Bx,
+    fx: &FunctionCx<'a, 'tcx, Bx>,
+    adt_def: &AdtDef,
+    ty_layout: &TyAndLayout<'tcx>,
+) -> ykpack::Ty {
+    let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
+    let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
+
+    if adt_def.variants.len() == 1 {
+        // Plain old struct-like thing.
+        let struct_layout = ty_layout.for_variant(bx, VariantIdx::from_u32(0));
+
+        match &ty_layout.fields {
+            FieldsShape::Arbitrary { offsets, .. } => {
+                let mut sir_offsets = Vec::new();
+                let mut sir_tys = Vec::new();
+                for (idx, offs) in offsets.iter().enumerate() {
+                    sir_tys.push(lower_ty_and_layout(tcx, bx, fx, &struct_layout.field(bx, idx)));
+                    sir_offsets.push(offs.bytes());
+                }
+
+                ykpack::Ty::Struct(ykpack::StructTy {
+                    offsets: sir_offsets,
+                    align,
+                    size,
+                    tys: sir_tys,
+                })
+            }
+            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
+        }
+    } else {
+        // An enum with variants.
+        ykpack::Ty::Unimplemented(format!("{:?}", ty_layout))
+    }
+}


### PR DESCRIPTION
I had intended to move this code into the SirFuncCx in rustc_middle, but due to the way the compiler crates depend on each other, this isn't going to be possible (backend types can't appear in librustc_middle).

As a compromise, move the code to its own file, so at least we minimise the chance of merge conflicts with upstream.

Also found a dead argument (second commit).