### PR TITLE
Add `do_not_trace` annotations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#2a79979e2c4537be1d824bbac1bd03c6ec185c4c"
+source = "git+https://github.com/softdevteam/yk#696046fffa586b1bb5e6a6cd20bfc9e732a3a9a9"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -236,6 +236,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Yorick: Markers for trimming traces.
     ungated!(trace_head, AssumedUsed, template!(Word)),
     ungated!(trace_tail, AssumedUsed, template!(Word)),
+    ungated!(do_not_trace, AssumedUsed, template!(Word)),
 
     ungated!(used, AssumedUsed, template!(Word)),
 

--- a/src/librustc_middle/sir.rs
+++ b/src/librustc_middle/sir.rs
@@ -86,6 +86,8 @@ impl SirFuncCx<'tcx> {
                 flags |= ykpack::bodyflags::TRACE_HEAD;
             } else if tcx.sess.check_name(attr, sym::trace_tail) {
                 flags |= ykpack::bodyflags::TRACE_TAIL;
+            } else if tcx.sess.check_name(attr, sym::do_not_trace) {
+                flags |= ykpack::bodyflags::DO_NOT_TRACE;
             }
         }
 

--- a/src/librustc_middle/sir.rs
+++ b/src/librustc_middle/sir.rs
@@ -109,6 +109,11 @@ impl SirFuncCx<'tcx> {
         let local_decls = Vec::with_capacity(mir.local_decls.len());
         let symbol_name = String::from(&*tcx.symbol_name(*instance).name);
 
+        let crate_name = tcx.crate_name(instance.def_id().krate).as_str();
+        if crate_name == "core" || crate_name == "alloc" {
+            flags |= ykpack::bodyflags::DO_NOT_TRACE;
+        }
+
         Self {
             func: ykpack::Body {
                 symbol_name,

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -428,6 +428,7 @@ symbols! {
         dispatch_from_dyn,
         div,
         div_assign,
+        do_not_trace,
         doc,
         doc_alias,
         doc_cfg,


### PR DESCRIPTION
This annotation tells the tracer to ignore the annotated function and turn it into a call instead of inlining it.

Companion PR: https://github.com/softdevteam/yk/pull/96