### PR TITLE
Mark thread tracer types in SIR.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#696046fffa586b1bb5e6a6cd20bfc9e732a3a9a9"
+source = "git+https://github.com/softdevteam/yk#fa7ade3d3992e8763d84c0c120dca7182ac3574d"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc_codegen_llvm/sir.rs
+++ b/src/librustc_codegen_llvm/sir.rs
@@ -38,7 +38,10 @@ pub fn write_sir<'tcx>(tcx: TyCtxt<'tcx>, sir_llvm_module: &mut ModuleLlvm) {
     let types =
         tcx.sir_types.borrow_mut().map.drain(..).map(|(k, _)| k).collect::<Vec<ykpack::Ty>>();
     let crate_hash = tcx.crate_hash(LOCAL_CRATE).as_u64();
-    encoder.serialise(ykpack::Pack::Types(ykpack::Types { crate_hash, types })).unwrap();
+    let thread_tracers = tcx.sir_types.borrow_mut().thread_tracers.drain().collect::<Vec<u32>>();
+    encoder
+        .serialise(ykpack::Pack::Types(ykpack::Types { crate_hash, types, thread_tracers }))
+        .unwrap();
 
     for func in sir_funcs {
         encoder.serialise(ykpack::Pack::Body(func)).unwrap();

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -230,13 +230,12 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(link_section, AssumedUsed, template!(NameValueStr: "name")),
     ungated!(no_mangle, AssumedUsed, template!(Word)),
 
-    // Yorick: "Don't software trace this". Disables the `AddYkSWTCalls` MIR transform.
+    // Yorick-related stuff.
     ungated!(no_sw_trace, AssumedUsed, template!(Word)),
-
-    // Yorick: Markers for trimming traces.
     ungated!(trace_head, AssumedUsed, template!(Word)),
     ungated!(trace_tail, AssumedUsed, template!(Word)),
     ungated!(do_not_trace, AssumedUsed, template!(Word)),
+    ungated!(thread_tracer, AssumedUsed, template!(Word)),
 
     ungated!(used, AssumedUsed, template!(Word)),
 

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -1091,6 +1091,7 @@ symbols! {
         then_with,
         thread,
         thread_local,
+        thread_tracer,
         tool_attributes,
         tool_lints,
         trace_head,


### PR DESCRIPTION
We do this so that we can ignore statements that reference the thread
tracer at runtime.