### PR TITLE
Fix global_asm

### DIFF
--- a/src/librustc_codegen_llvm/sir.rs
+++ b/src/librustc_codegen_llvm/sir.rs
@@ -85,6 +85,6 @@ pub fn write_sir<'tcx>(
         // Following the precedent of write_compressed_metadata(), force empty flags so that
         // the SIR doesn't get loaded into memory.
         let directive = format!(".section {}, \"\", @progbits", &section_name);
-        llvm::LLVMSetModuleInlineAsm2(sir_llmod, directive.as_ptr().cast(), directive.len())
+        llvm::LLVMRustAppendModuleInlineAsm(sir_llmod, directive.as_ptr().cast(), directive.len());
     }
 }


### PR DESCRIPTION
The SIR serialization code accidentally overwrote all global asm in the current cgu instead of appending it