### PR TITLE
crate_hash -> cgu_hash and don't hash the crate hash.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#bc531d69f674e725a4329608219184f2cb88a707"
+source = "git+https://github.com/softdevteam/yk#9b6e61ca67185acade1c0c7c386d4d083a2dc84d"
 dependencies = [
  "fallible-iterator",
  "rmp-serde",

--- a/src/librustc_codegen_llvm/declare.rs
+++ b/src/librustc_codegen_llvm/declare.rs
@@ -96,12 +96,12 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn define_sir_type(&self, ty: ykpack::Ty) -> ykpack::TypeId {
         let mut types = self.sir.as_ref().unwrap().types.borrow_mut();
-        (types.crate_hash, types.index(ty))
+        (types.cgu_hash, types.index(ty))
     }
 
     fn define_sir_thread_tracer(&self, type_id: ykpack::TypeId) {
         let mut types = self.sir.as_ref().unwrap().types.borrow_mut();
-        assert_eq!(types.crate_hash, type_id.0);
+        assert_eq!(types.cgu_hash, type_id.0);
         types.thread_tracers.insert(u32::try_from(type_id.1).unwrap());
     }
 

--- a/src/librustc_codegen_llvm/sir.rs
+++ b/src/librustc_codegen_llvm/sir.rs
@@ -42,7 +42,7 @@ pub fn write_sir<'tcx>(
     // the type indices, hence use of `IndexMap` for insertion order.
     encoder
         .serialise(ykpack::Pack::Types(ykpack::Types {
-            crate_hash: sir_types.crate_hash,
+            cgu_hash: sir_types.cgu_hash,
             types: sir_types.map.into_iter().map(|(k, _)| k).collect::<Vec<ykpack::Ty>>(),
             thread_tracers: sir_types.thread_tracers.into_iter().collect(),
         }))


### PR DESCRIPTION
The crate hash changes frequently (with every source code change), so we shouldn't use it in the CGU hash.

~~There is a companion commit coming for this and~~ we will need to do a cycle breaker.

Companion: https://github.com/softdevteam/yk/pull/113