### PR TITLE
Use structs (instead of tuples) for trace inputs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#56223feb6580e85f7470e2e6508afe2b2afa466e"
+source = "git+https://github.com/softdevteam/yk#02f7389286425020c20a0390d047b5930683a8a9"
 dependencies = [
  "bincode",
  "fallible-iterator",

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -594,11 +594,17 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             );
                         }
 
+                        let type_err = "trace inputs should be a struct";
+
                         // Check it's the right type.
                         let local_decl = &self.mir.local_decls[ret_place.local];
                         match local_decl.ty.kind {
-                            ty::Tuple(_) => (),
-                            _ => panic!("Argument to `trace_inputs()` should be a tuple."),
+                            ty::Adt(def, _) => {
+                                if def.variants.len() != 1 {
+                                    panic!(type_err);
+                                }
+                            }
+                            _ => panic!(type_err),
                         }
 
                         sfcx.func.trace_inputs_local = Some(sfcx.lower_local(ret_place.local));


### PR DESCRIPTION
This allows for named fields, which is much more ergonomic.

Companion PR ~~coming~~ https://github.com/softdevteam/yk/pull/125.