### PR TITLE
New IR.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5520,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#e8d31d2eca0e02172caa47dc159cb30a42dd60cf"
+source = "git+https://github.com/softdevteam/yk#3bc032d5c1e91b959532e0e6062b0eb281d7a7e6"
 dependencies = [
  "bincode",
  "fallible-iterator",

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -16,7 +16,7 @@ use rustc_index::vec::IndexVec;
 use self::analyze::CleanupKind;
 use self::debuginfo::{FunctionDebugContext, PerLocalVarDebugInfo};
 use self::place::PlaceRef;
-use crate::sir::{self, Sir, SirFuncCx};
+use crate::sir::{Sir, SirFuncCx};
 use rustc_middle::mir::traversal;
 
 use self::operand::{OperandRef, OperandValue};
@@ -182,7 +182,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let (landing_pads, funclets) = create_funclets(&mir, &mut bx, &cleanup_kinds, &block_bxs);
 
     let sir_func_cx = if Sir::is_required(cx.tcx()) {
-        Some(SirFuncCx::new(cx.tcx(), &instance, mir))
+        Some(SirFuncCx::new(&bx, cx.tcx(), &instance, mir))
     } else {
         None
     };
@@ -272,18 +272,6 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     for (bb, _) in rpo {
         visited.insert(bb.index());
         fx.codegen_block(bb);
-    }
-
-    // Serialise monomorphised local declarations to SIR.
-    // This has to happen after the blocks have been codegenned so that all of the
-    // `LocalRef::Operand`s have been fully resolved: they start `None` and are patched up during
-    // `codegen_rvalue_operand`.
-    if fx.sir_func_cx.is_some() {
-        let mut decls: Vec<ykpack::LocalDecl> = Vec::new();
-        for l in &fx.locals {
-            decls.push(sir::lower_local_ref(cx.tcx(), &bx, l));
-        }
-        fx.sir_func_cx.as_mut().unwrap().func.local_decls.extend(decls);
     }
 
     // Remove blocks that haven't been visited, or have no

--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -3,154 +3,27 @@
 //! SIR is built in-memory during code-generation (in rustc_codegen_ssa), and finally placed
 //! into an ELF section at link time.
 
-use crate::mir::LocalRef;
 use crate::traits::{BuilderMethods, SirMethods};
 use indexmap::IndexMap;
 use rustc_ast::ast;
 use rustc_ast::ast::{IntTy, UintTy};
-use rustc_data_structures::fx::FxHasher;
+use rustc_data_structures::fx::{FxHashMap, FxHasher};
 use rustc_hir::{self, def_id::LOCAL_CRATE};
 use rustc_middle::mir;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::AdtDef;
+use rustc_middle::ty::TypeFoldable;
 use rustc_middle::ty::{self, layout::TyAndLayout, TyCtxt};
 use rustc_middle::ty::{Instance, Ty};
 use rustc_span::sym;
 use rustc_target::abi::FieldsShape;
 use rustc_target::abi::VariantIdx;
 use std::cell::RefCell;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::default::Default;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::io;
 use ykpack;
-
-pub(crate) fn lower_local_ref<'a, 'l, 'tcx, Bx: BuilderMethods<'a, 'tcx>, V>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    decl: &'l LocalRef<'tcx, V>,
-) -> ykpack::LocalDecl {
-    let ty_layout = match decl {
-        LocalRef::Place(pref) => pref.layout,
-        LocalRef::UnsizedPlace(..) => {
-            let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::UnsizedPlace"));
-            return ykpack::LocalDecl { ty: bx.cx().define_sir_type(sir_ty) };
-        }
-        LocalRef::Operand(opt_oref) => {
-            if let Some(oref) = opt_oref {
-                oref.layout
-            } else {
-                let sir_ty = ykpack::Ty::Unimplemented(format!("LocalRef::OperandRef is None"));
-                return ykpack::LocalDecl { ty: bx.cx().define_sir_type(sir_ty) };
-            }
-        }
-    };
-
-    ykpack::LocalDecl { ty: lower_ty_and_layout(tcx, bx, &ty_layout) }
-}
-
-fn lower_ty_and_layout<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    ty_layout: &TyAndLayout<'tcx>,
-) -> ykpack::TypeId {
-    let sir_ty = match ty_layout.ty.kind() {
-        ty::Int(si) => lower_signed_int(*si),
-        ty::Uint(ui) => lower_unsigned_int(*ui),
-        ty::Adt(adt_def, ..) => lower_adt(tcx, bx, adt_def, &ty_layout),
-        ty::Array(typ, _) => ykpack::Ty::Array(lower_ty_and_layout(tcx, bx, &bx.layout_of(typ))),
-        ty::Slice(typ) => ykpack::Ty::Slice(lower_ty_and_layout(tcx, bx, &bx.layout_of(typ))),
-        ty::Ref(_, typ, _) => ykpack::Ty::Ref(lower_ty_and_layout(tcx, bx, &bx.layout_of(typ))),
-        ty::Bool => ykpack::Ty::Bool,
-        ty::Char => ykpack::Ty::Char,
-        ty::Tuple(..) => lower_tuple(tcx, bx, ty_layout),
-        _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
-    };
-    bx.cx().define_sir_type(sir_ty)
-}
-
-fn lower_signed_int(si: IntTy) -> ykpack::Ty {
-    match si {
-        IntTy::Isize => ykpack::Ty::SignedInt(ykpack::SignedIntTy::Isize),
-        IntTy::I8 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I8),
-        IntTy::I16 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I16),
-        IntTy::I32 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I32),
-        IntTy::I64 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I64),
-        IntTy::I128 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I128),
-    }
-}
-
-fn lower_unsigned_int(ui: UintTy) -> ykpack::Ty {
-    match ui {
-        UintTy::Usize => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::Usize),
-        UintTy::U8 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U8),
-        UintTy::U16 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U16),
-        UintTy::U32 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U32),
-        UintTy::U64 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U64),
-        UintTy::U128 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U128),
-    }
-}
-
-fn lower_tuple<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    ty_layout: &TyAndLayout<'tcx>,
-) -> ykpack::Ty {
-    let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
-    let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
-
-    match &ty_layout.fields {
-        FieldsShape::Arbitrary { offsets, .. } => {
-            let mut sir_offsets = Vec::new();
-            let mut sir_tys = Vec::new();
-            for (idx, offs) in offsets.iter().enumerate() {
-                sir_tys.push(lower_ty_and_layout(tcx, bx, &ty_layout.field(bx, idx)));
-                sir_offsets.push(offs.bytes());
-            }
-
-            ykpack::Ty::Tuple(ykpack::TupleTy {
-                fields: ykpack::Fields { offsets: sir_offsets, tys: sir_tys },
-                size_align: ykpack::SizeAndAlign { size, align },
-            })
-        }
-        _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
-    }
-}
-
-fn lower_adt<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    bx: &Bx,
-    adt_def: &AdtDef,
-    ty_layout: &TyAndLayout<'tcx>,
-) -> ykpack::Ty {
-    let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
-    let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
-
-    if adt_def.variants.len() == 1 {
-        // Plain old struct-like thing.
-        let struct_layout = ty_layout.for_variant(bx, VariantIdx::from_u32(0));
-
-        match &ty_layout.fields {
-            FieldsShape::Arbitrary { offsets, .. } => {
-                let mut sir_offsets = Vec::new();
-                let mut sir_tys = Vec::new();
-                for (idx, offs) in offsets.iter().enumerate() {
-                    sir_tys.push(lower_ty_and_layout(tcx, bx, &struct_layout.field(bx, idx)));
-                    sir_offsets.push(offs.bytes());
-                }
-
-                ykpack::Ty::Struct(ykpack::StructTy {
-                    fields: ykpack::Fields { offsets: sir_offsets, tys: sir_tys },
-                    size_align: ykpack::SizeAndAlign { align, size },
-                })
-            }
-            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
-        }
-    } else {
-        // An enum with variants.
-        ykpack::Ty::Unimplemented(format!("{:?}", ty_layout))
-    }
-}
 
 const BUILD_SCRIPT_CRATE: &str = "build_script_build";
 const CHECKABLE_BINOPS: [ykpack::BinOp; 5] = [
@@ -226,12 +99,27 @@ impl Sir {
 
 /// A structure for building the SIR of a function.
 pub struct SirFuncCx<'tcx> {
+    /// The instance we are lowering.
+    instance: Instance<'tcx>,
+    /// The MIR body of the above instance.
+    mir: &'tcx mir::Body<'tcx>,
+    /// The SIR function we are building.
     pub func: ykpack::Body,
+    /// Maps each MIR local to a SIR IPlace.
+    var_map: FxHashMap<mir::Local, ykpack::IPlace>,
+    /// The next SIR local variable index to be allocated.
+    next_sir_local: ykpack::LocalIndex,
+    /// The compiler's type context.
     tcx: TyCtxt<'tcx>,
 }
 
 impl SirFuncCx<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>, mir: &mir::Body<'_>) -> Self {
+    pub fn new<Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &Bx,
+        tcx: TyCtxt<'tcx>,
+        instance: &Instance<'tcx>,
+        mir: &'tcx mir::Body<'tcx>,
+    ) -> Self {
         let mut flags = 0;
         for attr in tcx.get_attrs(instance.def_id()).iter() {
             if tcx.sess.check_name(attr, sym::do_not_trace) {
@@ -285,6 +173,7 @@ impl SirFuncCx<'tcx> {
             mir.basic_blocks().len()
         ];
 
+        // There will be at least as many locals in the SIR as there are in the MIR.
         let local_decls = Vec::with_capacity(mir.local_decls.len());
         let symbol_name = String::from(&*tcx.symbol_name(*instance).name);
 
@@ -292,11 +181,69 @@ impl SirFuncCx<'tcx> {
         if crate_name == "core" || crate_name == "alloc" {
             flags |= ykpack::bodyflags::DO_NOT_TRACE;
         }
+        let var_map: FxHashMap<mir::Local, ykpack::IPlace> = FxHashMap::default();
 
-        Self {
+        let mut this = Self {
+            instance: instance.clone(),
+            mir,
             func: ykpack::Body { symbol_name, blocks, flags, local_decls, num_args: mir.arg_count },
+            var_map,
+            next_sir_local: 0,
             tcx,
+        };
+
+        // Allocate return local and args in their anchored positions.
+        for idx in 0..=mir.arg_count {
+            let ml = mir::Local::from_usize(idx);
+            let sirty =
+                this.lower_ty_and_layout(bx, &this.mono_layout_of(bx, this.mir.local_decls[ml].ty));
+            this.func.local_decls.push(ykpack::LocalDecl { ty: sirty, referenced: false });
+            this.var_map.insert(
+                ml,
+                ykpack::IPlace::Val {
+                    local: ykpack::Local(u32::try_from(idx).unwrap()),
+                    off: 0,
+                    ty: sirty,
+                },
+            );
+            this.next_sir_local += 1;
         }
+        this
+    }
+
+    /// Returns the IPlace corresponding with MIR local `ml`. A new IPlace is constructed if we've
+    /// never seen this MIR local before.
+    fn sir_local<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        ml: &mir::Local,
+    ) -> ykpack::IPlace {
+        let ret = if let Some(ip) = self.var_map.get(ml) {
+            ip.clone()
+        } else {
+            let sirty = self
+                .lower_ty_and_layout(bx, &self.mono_layout_of(bx, self.mir.local_decls[*ml].ty));
+            let nl = self.new_sir_local(sirty);
+            self.var_map.insert(*ml, nl.clone());
+            nl
+        };
+        ret
+    }
+
+    /// Returns a zero-offset IPlace for a new SIR local.
+    fn new_sir_local(&mut self, sirty: ykpack::TypeId) -> ykpack::IPlace {
+        let idx = self.next_sir_local;
+        self.next_sir_local += 1;
+        self.func.local_decls.push(ykpack::LocalDecl { ty: sirty, referenced: false });
+        ykpack::IPlace::Val { local: ykpack::Local(idx), off: 0, ty: sirty }
+    }
+
+    /// Tells the tracer codegen that the local `l` is referenced, and that is should be allocated
+    /// directly to the stack and not a register. You can't reference registers.
+    fn notify_referenced(&mut self, l: ykpack::Local) {
+        let idx = usize::try_from(l.0).unwrap();
+        let slot = self.func.local_decls.get_mut(idx).unwrap();
+        slot.referenced = true;
     }
 
     /// Returns true if there are no basic blocks.
@@ -317,10 +264,11 @@ impl SirFuncCx<'tcx> {
         *term = new_term
     }
 
-    pub fn set_term_switchint(
+    pub fn set_term_switchint<Bx: BuilderMethods<'a, 'tcx>>(
         &mut self,
+        bx: &Bx,
         bb: ykpack::BasicBlockIndex,
-        discr: &mir::Operand<'_>,
+        discr: &mir::Operand<'tcx>,
         values: Vec<ykpack::SerU128>,
         targets: &Vec<mir::BasicBlock>,
     ) {
@@ -328,7 +276,7 @@ impl SirFuncCx<'tcx> {
         let mut targetsnew: Vec<u32> = targets.iter().map(|bb| bb.as_u32()).collect();
         let otherwise = targetsnew.pop().expect("SwitchInt can't have empty targets?");
         let new_term = ykpack::Terminator::SwitchInt {
-            discr: self.lower_operand(discr),
+            discr: self.lower_operand(bx, bb, discr),
             values: values,
             target_bbs: targetsnew,
             otherwise_bb: otherwise,
@@ -341,11 +289,15 @@ impl SirFuncCx<'tcx> {
     }
 
     /// Converts a MIR statement to SIR, appending the result to `bb`.
-    pub fn lower_statement(&mut self, bb: ykpack::BasicBlockIndex, stmt: &mir::Statement<'_>) {
+    pub fn lower_statement<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        stmt: &mir::Statement<'tcx>,
+    ) {
         match stmt.kind {
             mir::StatementKind::Assign(box (ref place, ref rvalue)) => {
-                let assign = self.lower_assign_stmt(place, rvalue);
-                self.push_stmt(bb, assign);
+                self.lower_assign_stmt(bx, bb, place, rvalue)
             }
             // We compute our own liveness in Yorick, so these are ignored.
             mir::StatementKind::StorageLive(_) | mir::StatementKind::StorageDead(_) => {}
@@ -353,90 +305,277 @@ impl SirFuncCx<'tcx> {
         }
     }
 
-    fn lower_assign_stmt(
-        &self,
-        lvalue: &mir::Place<'_>,
-        rvalue: &mir::Rvalue<'_>,
-    ) -> ykpack::Statement {
-        let lhs = self.lower_place(lvalue);
-        let rhs = self.lower_rvalue(rvalue);
-        ykpack::Statement::Assign(lhs, rhs)
+    fn lower_assign_stmt<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        lvalue: &mir::Place<'tcx>,
+        rvalue: &mir::Rvalue<'tcx>,
+    ) {
+        let dest_ty = lvalue.ty(self.mir, self.tcx).ty;
+        let rhs = self.lower_rvalue(bx, bb, dest_ty, rvalue);
+
+        // FIXME optimisation.
+        // If the store can't affect any state observable from outside the function, then don't
+        // emit a store, but instead just update the mapping. This will remove many unnecessary
+        // stores and also act as a kind of constant propagation.
+        let lhs = self.lower_place(bx, bb, lvalue);
+        self.push_stmt(bb, ykpack::Statement::Store(lhs, rhs));
     }
 
-    pub fn lower_operand(&self, operand: &mir::Operand<'_>) -> ykpack::Operand {
+    pub fn lower_operand<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        operand: &mir::Operand<'tcx>,
+    ) -> ykpack::IPlace {
         match operand {
             mir::Operand::Copy(place) | mir::Operand::Move(place) => {
-                ykpack::Operand::Place(self.lower_place(place))
+                self.lower_place(bx, bb, place)
             }
-            mir::Operand::Constant(cst) => ykpack::Operand::Constant(self.lower_constant(cst)),
+            mir::Operand::Constant(cst) => self.lower_constant(bx, cst),
         }
     }
 
-    fn lower_rvalue(&self, rvalue: &mir::Rvalue<'_>) -> ykpack::Rvalue {
+    fn lower_cast_misc<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        op: &mir::Operand<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> ykpack::IPlace {
+        let lop = self.lower_operand(bx, bb, op);
+
+        // The ty we are casting to is equivalent to dest_ty.
+        let ty = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, ty));
+        let dest_ip = self.new_sir_local(ty);
+        let stmt = ykpack::Statement::Cast(dest_ip.clone(), lop);
+        self.push_stmt(bb, stmt);
+        dest_ip
+    }
+
+    fn lower_rvalue<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        dest_ty: Ty<'tcx>,
+        rvalue: &mir::Rvalue<'tcx>,
+    ) -> ykpack::IPlace {
         match rvalue {
-            mir::Rvalue::Use(opnd) => ykpack::Rvalue::Use(self.lower_operand(opnd)),
-            mir::Rvalue::BinaryOp(op, opnd1, opnd2) => self.lower_binop(*op, opnd1, opnd2, false),
-            mir::Rvalue::CheckedBinaryOp(op, opnd1, opnd2) => {
-                self.lower_binop(*op, opnd1, opnd2, true)
+            mir::Rvalue::Use(opnd) => self.lower_operand(bx, bb, opnd),
+            mir::Rvalue::Ref(_, _, p) => self.lower_ref(bx, bb, dest_ty, p),
+            mir::Rvalue::BinaryOp(op, opnd1, opnd2) => {
+                self.lower_binop(bx, bb, dest_ty, *op, opnd1, opnd2, false)
             }
-            mir::Rvalue::Ref(_, _, place) => self.lower_ref(place),
-            mir::Rvalue::Len(place) => ykpack::Rvalue::Len(self.lower_place(place)),
-            mir::Rvalue::Cast(mir::CastKind::Misc, op, ty) => self.lower_cast_misc(op, ty),
-            _ => ykpack::Rvalue::Unimplemented(with_no_trimmed_paths(|| {
+            mir::Rvalue::CheckedBinaryOp(op, opnd1, opnd2) => {
+                self.lower_binop(bx, bb, dest_ty, *op, opnd1, opnd2, true)
+            }
+            mir::Rvalue::Cast(mir::CastKind::Misc, op, ty) => self.lower_cast_misc(bx, bb, op, ty),
+            _ => ykpack::IPlace::Unimplemented(with_no_trimmed_paths(|| {
                 format!("unimplemented rvalue: {:?}", rvalue)
             })),
         }
     }
 
-    pub fn lower_place(&self, place: &mir::Place<'_>) -> ykpack::Place {
-        ykpack::Place {
-            local: self.lower_local(place.local),
-            // FIXME projections not yet implemented.
-            projection: place.projection.iter().map(|p| self.lower_projection(&p)).collect(),
+    fn monomorphize<T>(&self, value: &T) -> T
+    where
+        T: TypeFoldable<'tcx> + Copy,
+    {
+        if let Some(substs) = self.instance.substs_for_mir_body() {
+            self.tcx.subst_and_normalize_erasing_regions(substs, ty::ParamEnv::reveal_all(), value)
+        } else {
+            self.tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), *value)
         }
     }
 
-    pub fn lower_projection(&self, pe: &mir::PlaceElem<'_>) -> ykpack::Projection {
-        match pe {
-            mir::ProjectionElem::Field(field, ..) => ykpack::Projection::Field(field.as_u32()),
-            mir::ProjectionElem::Deref => ykpack::Projection::Deref,
-            mir::ProjectionElem::Index(local) => {
-                ykpack::Projection::Index(self.lower_local(*local))
+    /// Wrapper for bx.layout_of() which ensures the type is first monomorphised.
+    fn mono_layout_of<Bx: BuilderMethods<'a, 'tcx>>(
+        &self,
+        bx: &Bx,
+        t: Ty<'tcx>,
+    ) -> TyAndLayout<'tcx> {
+        bx.layout_of(self.monomorphize(&t))
+    }
+
+    /// Apply an offset to an IPlace.
+    fn offset_iplace<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        mut ip: ykpack::IPlace,
+        add: ykpack::OffT,
+        mirty: Ty<'tcx>,
+    ) -> ykpack::IPlace {
+        match &mut ip {
+            ykpack::IPlace::Val { off, ty, .. } => {
+                *off += add;
+                *ty = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, mirty));
+                ip
             }
-            _ => ykpack::Projection::Unimplemented(format!("{:?}", pe)),
+            ykpack::IPlace::Indirect { off, ty, .. } => {
+                *off += add;
+                *ty = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, mirty));
+                ip
+            }
+            ykpack::IPlace::Const { .. } => {
+                ykpack::IPlace::Unimplemented("offset_iplace on a constant".to_owned())
+            }
+            ykpack::IPlace::Unimplemented(_) => ip,
         }
     }
 
-    pub fn lower_local(&self, local: mir::Local) -> ykpack::Local {
-        // For the lowering of `Local`s we currently assume a 1:1 mapping from MIR to SIR. If this
-        // mapping turns out to be impossible or impractial, this is the place to change it.
-        ykpack::Local(local.as_u32())
+    pub fn lower_place<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        place: &mir::Place<'_>,
+    ) -> ykpack::IPlace {
+        // We start with the base local and project away from it.
+        let mut cur_iplace = self.sir_local(bx, &place.local);
+        let mut cur_mirty = self.monomorphize(&self.mir.local_decls[place.local].ty);
+
+        // Loop over the projection chain, updating cur_iplace as we go.
+        for pj in place.projection {
+            let next_mirty = match pj {
+                mir::ProjectionElem::Field(f, _) => {
+                    let fi = f.as_usize();
+                    match cur_mirty.kind() {
+                        ty::Adt(def, _) => {
+                            if def.is_struct() {
+                                let ty_lay = self.mono_layout_of(bx, cur_mirty);
+                                let st_lay = ty_lay.for_variant(bx, VariantIdx::from_u32(0));
+                                if let FieldsShape::Arbitrary { offsets, .. } = &st_lay.fields {
+                                    let new_mirty = st_lay.field(bx, fi).ty;
+                                    cur_iplace = self.offset_iplace(
+                                        bx,
+                                        cur_iplace,
+                                        offsets[fi].bytes().try_into().unwrap(),
+                                        new_mirty,
+                                    );
+                                    new_mirty
+                                } else {
+                                    return ykpack::IPlace::Unimplemented(format!(
+                                        "struct field shape: {:?}",
+                                        st_lay.fields
+                                    ));
+                                }
+                            } else if def.is_enum() {
+                                return ykpack::IPlace::Unimplemented(format!(
+                                    "enum_projection: {:?}",
+                                    def
+                                ));
+                            } else {
+                                return ykpack::IPlace::Unimplemented(format!("adt: {:?}", def));
+                            }
+                        }
+                        ty::Tuple(..) => {
+                            let tup_lay = self.mono_layout_of(bx, cur_mirty);
+                            match &tup_lay.fields {
+                                FieldsShape::Arbitrary { offsets, .. } => {
+                                    let new_mirty = tup_lay.field(bx, fi).ty;
+                                    cur_iplace = self.offset_iplace(
+                                        bx,
+                                        cur_iplace,
+                                        offsets[fi].bytes().try_into().unwrap(),
+                                        new_mirty,
+                                    );
+                                    new_mirty
+                                }
+                                _ => {
+                                    return ykpack::IPlace::Unimplemented(format!(
+                                        "tuple field shape: {:?}",
+                                        tup_lay.fields
+                                    ));
+                                }
+                            }
+                        }
+                        _ => {
+                            return ykpack::IPlace::Unimplemented(format!(
+                                "field access on: {:?}",
+                                cur_mirty
+                            ));
+                        }
+                    }
+                }
+                mir::ProjectionElem::Index(idx) => {
+                    if let ty::Array(elem_ty, ..) = cur_mirty.kind() {
+                        let arr_lay = self.mono_layout_of(bx, cur_mirty);
+                        let elem_size = match &arr_lay.fields {
+                            FieldsShape::Array { stride, .. } => {
+                                u32::try_from(stride.bytes_usize()).unwrap()
+                            }
+                            _ => unreachable!(),
+                        };
+
+                        let dest_ty =
+                            self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, elem_ty));
+                        let dest = self.new_sir_local(dest_ty);
+                        let idx_ip = self.sir_local(bx, &idx);
+                        let stmt = ykpack::Statement::DynOffs {
+                            dest: dest.clone(),
+                            base: cur_iplace.clone(),
+                            idx: idx_ip,
+                            scale: elem_size,
+                        };
+                        self.push_stmt(bb, stmt);
+                        cur_iplace = dest.to_indirect(dest_ty);
+                        elem_ty
+                    } else {
+                        return ykpack::IPlace::Unimplemented(format!("index on {:?}", cur_mirty));
+                    }
+                }
+                mir::ProjectionElem::Deref => {
+                    if let ty::Ref(_, ty, _) = cur_mirty.kind() {
+                        if let ykpack::IPlace::Indirect { ty: dty, .. } = cur_iplace {
+                            // We are dereffing an already indirect place, so we emit an
+                            // intermediate store to strip away one level of indirection.
+                            let dest = self.new_sir_local(dty);
+                            let deref = ykpack::Statement::Store(dest.clone(), cur_iplace.clone());
+                            self.push_stmt(bb, deref);
+                            cur_iplace = dest;
+                        }
+
+                        if let Some(l) = cur_iplace.local() {
+                            self.notify_referenced(l);
+                        }
+
+                        let tyid = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, ty));
+                        cur_iplace = cur_iplace.to_indirect(tyid);
+                        ty
+                    } else {
+                        return ykpack::IPlace::Unimplemented(format!("deref non-ref"));
+                    }
+                }
+                _ => return ykpack::IPlace::Unimplemented(format!("projection: {:?}", pj)),
+            };
+            cur_mirty = self.monomorphize(&next_mirty);
+        }
+        cur_iplace
     }
 
-    fn lower_cast_misc(&self, op: &mir::Operand<'_>, ty: Ty<'_>) -> ykpack::Rvalue {
-        let lop = self.lower_operand(op);
-        let lty = match ty.kind() {
-            ty::Int(si) => lower_signed_int(*si),
-            ty::Uint(ui) => lower_unsigned_int(*ui),
-            ty::Bool => ykpack::Ty::Bool,
-            ty::Char => ykpack::Ty::Char,
-            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty)),
-        };
-        ykpack::Rvalue::Cast(lop, lty)
-    }
-
-    fn lower_constant(&self, constant: &mir::Constant<'_>) -> ykpack::Constant {
+    fn lower_constant<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        constant: &mir::Constant<'tcx>,
+    ) -> ykpack::IPlace {
         match constant.literal.val {
             ty::ConstKind::Value(mir::interpret::ConstValue::Scalar(s)) => {
-                self.lower_scalar(constant.literal.ty, s)
+                let val = self.lower_scalar(bx, constant.literal.ty, s);
+                let ty =
+                    self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, constant.literal.ty));
+                ykpack::IPlace::Const { val, ty }
             }
-            _ => ykpack::Constant::Unimplemented(with_no_trimmed_paths(|| {
+            _ => ykpack::IPlace::Unimplemented(with_no_trimmed_paths(|| {
                 format!("unimplemented constant: {:?}", constant)
             })),
         }
     }
 
-    fn lower_scalar(&self, ty: Ty<'_>, s: mir::interpret::Scalar) -> ykpack::Constant {
+    fn lower_scalar<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        ty: Ty<'tcx>,
+        s: mir::interpret::Scalar,
+    ) -> ykpack::Constant {
         match ty.kind() {
             ty::Uint(uint) => self
                 .lower_uint(*uint, s)
@@ -459,6 +598,18 @@ impl SirFuncCx<'tcx> {
                     ))
                 }),
             ty::Bool => self.lower_bool(s),
+            ty::Tuple(_) => {
+                // FIXME for now just the unit tuple. Need to implement arbitrary scalar tuples.
+                if ty.is_unit() {
+                    let tyid = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, ty));
+                    ykpack::Constant::Tuple(tyid)
+                } else {
+                    ykpack::Constant::Unimplemented(format!(
+                        "unimplemented scalar: {:?}",
+                        ty.kind()
+                    ))
+                }
+            }
             _ => ykpack::Constant::Unimplemented(format!("unimplemented scalar: {:?}", ty.kind())),
         }
     }
@@ -524,26 +675,33 @@ impl SirFuncCx<'tcx> {
             _ => Err(()),
         }
     }
-    fn lower_binop(
-        &self,
+
+    fn lower_binop<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        dest_ty: Ty<'tcx>,
         op: mir::BinOp,
-        opnd1: &mir::Operand<'_>,
-        opnd2: &mir::Operand<'_>,
+        opnd1: &mir::Operand<'tcx>,
+        opnd2: &mir::Operand<'tcx>,
         checked: bool,
-    ) -> ykpack::Rvalue {
-        let sir_op = binop_lowerings!(
+    ) -> ykpack::IPlace {
+        let op = binop_lowerings!(
             op, Add, Sub, Mul, Div, Rem, BitXor, BitAnd, BitOr, Shl, Shr, Eq, Lt, Le, Ne, Ge, Gt,
             Offset
         );
-        let sir_opnd1 = self.lower_operand(opnd1);
-        let sir_opnd2 = self.lower_operand(opnd2);
+        let opnd1 = self.lower_operand(bx, bb, opnd1);
+        let opnd2 = self.lower_operand(bx, bb, opnd2);
 
         if checked {
-            debug_assert!(CHECKABLE_BINOPS.contains(&sir_op));
-            ykpack::Rvalue::CheckedBinaryOp(sir_op, sir_opnd1, sir_opnd2)
-        } else {
-            ykpack::Rvalue::BinaryOp(sir_op, sir_opnd1, sir_opnd2)
+            debug_assert!(CHECKABLE_BINOPS.contains(&op));
         }
+
+        let ty = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, dest_ty));
+        let dest_ip = self.new_sir_local(ty);
+        let stmt = ykpack::Statement::BinaryOp { dest: dest_ip.clone(), op, opnd1, opnd2, checked };
+        self.push_stmt(bb, stmt);
+        dest_ip
     }
 
     fn lower_bool(&self, s: mir::interpret::Scalar) -> ykpack::Constant {
@@ -553,9 +711,141 @@ impl SirFuncCx<'tcx> {
         }
     }
 
-    fn lower_ref(&self, place: &mir::Place<'_>) -> ykpack::Rvalue {
-        let sir_place = self.lower_place(place);
-        ykpack::Rvalue::Ref(sir_place)
+    fn lower_ref<Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        bb: ykpack::BasicBlockIndex,
+        dest_ty: Ty<'tcx>,
+        place: &mir::Place<'tcx>,
+    ) -> ykpack::IPlace {
+        let ty = self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, dest_ty));
+        let dest_ip = self.new_sir_local(ty);
+        let src_ip = self.lower_place(bx, bb, place);
+        let mkref = ykpack::Statement::MkRef(dest_ip.clone(), src_ip.clone());
+        if let Some(src_local) = src_ip.local() {
+            self.notify_referenced(src_local);
+        }
+        self.push_stmt(bb, mkref);
+        dest_ip
+    }
+
+    fn lower_ty_and_layout<'a, Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        ty_layout: &TyAndLayout<'tcx>,
+    ) -> ykpack::TypeId {
+        let sir_ty = match ty_layout.ty.kind() {
+            ty::Int(si) => self.lower_signed_int_ty(*si),
+            ty::Uint(ui) => self.lower_unsigned_int_ty(*ui),
+            ty::Adt(adt_def, ..) => self.lower_adt_ty(bx, adt_def, &ty_layout),
+            ty::Array(elem_ty, len) => {
+                let align = usize::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
+                let size = usize::try_from(ty_layout.layout.size.bytes()).unwrap();
+                ykpack::Ty::Array {
+                    elem_ty: self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, elem_ty)),
+                    len: usize::try_from(len.eval_usize(self.tcx, ty::ParamEnv::reveal_all()))
+                        .unwrap(),
+                    size_align: ykpack::SizeAndAlign {
+                        size: size.try_into().unwrap(),
+                        align: align.try_into().unwrap(),
+                    },
+                }
+            }
+            ty::Slice(typ) => {
+                ykpack::Ty::Slice(self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, typ)))
+            }
+            ty::Ref(_, typ, _) => {
+                ykpack::Ty::Ref(self.lower_ty_and_layout(bx, &self.mono_layout_of(bx, typ)))
+            }
+            ty::Bool => ykpack::Ty::Bool,
+            ty::Char => ykpack::Ty::Char,
+            ty::Tuple(..) => self.lower_tuple_ty(bx, ty_layout),
+            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
+        };
+        bx.cx().define_sir_type(sir_ty)
+    }
+
+    fn lower_signed_int_ty(&mut self, si: IntTy) -> ykpack::Ty {
+        match si {
+            IntTy::Isize => ykpack::Ty::SignedInt(ykpack::SignedIntTy::Isize),
+            IntTy::I8 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I8),
+            IntTy::I16 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I16),
+            IntTy::I32 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I32),
+            IntTy::I64 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I64),
+            IntTy::I128 => ykpack::Ty::SignedInt(ykpack::SignedIntTy::I128),
+        }
+    }
+
+    fn lower_unsigned_int_ty(&mut self, ui: UintTy) -> ykpack::Ty {
+        match ui {
+            UintTy::Usize => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::Usize),
+            UintTy::U8 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U8),
+            UintTy::U16 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U16),
+            UintTy::U32 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U32),
+            UintTy::U64 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U64),
+            UintTy::U128 => ykpack::Ty::UnsignedInt(ykpack::UnsignedIntTy::U128),
+        }
+    }
+
+    fn lower_tuple_ty<'a, Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        ty_layout: &TyAndLayout<'tcx>,
+    ) -> ykpack::Ty {
+        let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
+        let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
+
+        match &ty_layout.fields {
+            FieldsShape::Arbitrary { offsets, .. } => {
+                let mut sir_offsets = Vec::new();
+                let mut sir_tys = Vec::new();
+                for (idx, off) in offsets.iter().enumerate() {
+                    sir_tys.push(self.lower_ty_and_layout(bx, &ty_layout.field(bx, idx)));
+                    sir_offsets.push(off.bytes().try_into().unwrap());
+                }
+
+                ykpack::Ty::Tuple(ykpack::TupleTy {
+                    fields: ykpack::Fields { offsets: sir_offsets, tys: sir_tys },
+                    size_align: ykpack::SizeAndAlign { size, align },
+                })
+            }
+            _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
+        }
+    }
+
+    fn lower_adt_ty<'a, Bx: BuilderMethods<'a, 'tcx>>(
+        &mut self,
+        bx: &Bx,
+        adt_def: &AdtDef,
+        ty_layout: &TyAndLayout<'tcx>,
+    ) -> ykpack::Ty {
+        let align = i32::try_from(ty_layout.layout.align.abi.bytes()).unwrap();
+        let size = i32::try_from(ty_layout.layout.size.bytes()).unwrap();
+
+        if adt_def.variants.len() == 1 {
+            // Plain old struct-like thing.
+            let struct_layout = ty_layout.for_variant(bx, VariantIdx::from_u32(0));
+
+            match &ty_layout.fields {
+                FieldsShape::Arbitrary { offsets, .. } => {
+                    let mut sir_offsets = Vec::new();
+                    let mut sir_tys = Vec::new();
+                    for (idx, off) in offsets.iter().enumerate() {
+                        sir_tys.push(self.lower_ty_and_layout(bx, &struct_layout.field(bx, idx)));
+                        sir_offsets.push(off.bytes().try_into().unwrap());
+                    }
+
+                    ykpack::Ty::Struct(ykpack::StructTy {
+                        fields: ykpack::Fields { offsets: sir_offsets, tys: sir_tys },
+                        size_align: ykpack::SizeAndAlign { align, size },
+                    })
+                }
+                _ => ykpack::Ty::Unimplemented(format!("{:?}", ty_layout)),
+            }
+        } else {
+            // An enum with variants.
+            ykpack::Ty::Unimplemented(format!("{:?}", ty_layout))
+        }
     }
 }
 


### PR DESCRIPTION
This is a new design for SIR (and therefore TIR). The new design
resolves as many projections at SIR generation time so that they don't
have to be done at runtime. By doing so, we lessen the burden on the
trace code generator and the register allocator.

This is a companion to https://github.com/softdevteam/yk/pull/140