### PR TITLE
Better error messages for bogus #[interp_step] functions.

### DIFF
--- a/src/test/compile-fail/yk/interp-step-arg-not-ref.rs
+++ b/src/test/compile-fail/yk/interp-step-arg-not-ref.rs
@@ -1,0 +1,8 @@
+// compile-flags: -C tracer=hw -C opt-level=0
+
+fn main() {
+    f1(5);
+}
+
+#[interp_step]
+fn f1(_io: u8) {} //~ ERROR The #[interp_step] function must accept a mutable reference to a struct

--- a/src/test/compile-fail/yk/interp-step-env.rs
+++ b/src/test/compile-fail/yk/interp-step-env.rs
@@ -1,0 +1,13 @@
+// compile-flags: -C tracer=hw -C opt-level=0
+#![feature(stmt_expr_attributes)]
+
+struct IO(u8);
+
+fn main() {
+    let y = 6;
+    let f1 = #[interp_step] |io: &mut IO| {
+        //~^ ERROR The #[interp_step] function must not capture from its environment
+        io.0 = y
+    };
+    f1(&mut IO(0));
+}

--- a/src/test/compile-fail/yk/interp-step-num-args.rs
+++ b/src/test/compile-fail/yk/interp-step-num-args.rs
@@ -1,0 +1,8 @@
+// compile-flags: -C tracer=hw -C opt-level=0
+
+fn main() {
+    f1();
+}
+
+#[interp_step]
+fn f1() {} //~ ERROR The #[interp_step] function must accept only one argument

--- a/src/test/compile-fail/yk/interp-step-wrong-ret.rs
+++ b/src/test/compile-fail/yk/interp-step-wrong-ret.rs
@@ -1,0 +1,12 @@
+// compile-flags: -C tracer=hw -C opt-level=0
+
+struct IO();
+
+fn main() {
+    f1(&mut IO());
+}
+
+#[interp_step]
+fn f1(_io: &mut IO) -> u8 { //~ ERROR: The #[interp_step] function must return unit
+    0
+}


### PR DESCRIPTION
Instead of just bombing out without any useful location information, we
now point out the troublesome function definition.

Also make the errors fatal. Fixes a vector out of bounds problem when the
trace-related code tries to find the trace IO.

E.g.:
```
error: The #[interp_step] function must accept only one argument
  --> /home/vext01/research/yorick/ykrustc/src/test/compile-fail/yk/interp-step.rs:8:1
   |
LL | fn f1() {}
   | ^^^^^^^
```