### PR TITLE
Insert TraceDebugCall terminators when yktrace::trace_debug is used.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "ykpack"
 version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#a866ebc92b6a2f584bb4a066202f9520108d6e00"
+source = "git+https://github.com/softdevteam/yk#1095caab5c4496fd08e5ace9d07f292118479a11"
 dependencies = [
  "bincode",
  "fallible-iterator",

--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -162,6 +162,8 @@ impl SirFuncCx<'tcx> {
                 }
 
                 flags |= ykpack::bodyflags::INTERP_STEP;
+            } else if tcx.sess.check_name(attr, sym::trace_debug) {
+                flags |= ykpack::bodyflags::TRACE_DEBUG;
             }
         }
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -236,6 +236,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Yorick-related stuff.
     ungated!(do_not_trace, AssumedUsed, template!(Word)),
     ungated!(interp_step, AssumedUsed, template!(Word)),
+    ungated!(trace_debug, AssumedUsed, template!(Word)),
 
     ungated!(used, AssumedUsed, template!(Word)),
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1115,6 +1115,7 @@ symbols! {
         thread_local,
         tool_attributes,
         tool_lints,
+        trace_debug,
         trace_macros,
         track_caller,
         trait_alias,


### PR DESCRIPTION
Companion to https://github.com/softdevteam/yk/pull/152