### PR TITLE
Patch the yk dep using a special line in the PR description.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -16,8 +16,9 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
+# This step requires the 'github3.py' python module.
 pr_no=`git show HEAD | awk '/(Merge #|Try #)/ {print substr($2, 2)}'`
-echo `python3 .buildbot_patch_yk_dep.py ${pr_no}`
+/opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py ${pr_no}
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml --stage 2

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -17,8 +17,9 @@ ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
 # This step requires the 'github3.py' python module.
-pr_no=`git show HEAD | awk '/(Merge #|Try #)/ {print substr($2, 2)}'`
+pr_no=`git show HEAD | awk  '/(Merge #|Try #)/ {gsub(/ /, "", $2); gsub (/:/, "", $2); print substr($2, 1, length($2) - 1)}'`
 /opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py ${pr_no}
+exit 1
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml --stage 2

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -16,7 +16,7 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
-# This step requires the 'github3.py' and 'github2' Python modules.
+# This step requires the 'github3.py' module.
 /opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py
 
 # Note that the gdb must be Python enabled.

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,7 +2,7 @@
 #
 # Build script for continuous integration.
 
-set -e
+set -ex
 
 export PATH=PATH=/opt/gdb-8.2/bin:${PATH}
 
@@ -17,6 +17,7 @@ ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
 # This step requires the 'github3.py' python module.
+git show # XXX debug
 pr_no=`git show HEAD | awk  '/(Merge #|Try #)/ {gsub(/ /, "", $2); gsub (/:/, "", $2); print substr($2, 1, length($2) - 1)}'`
 /opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py ${pr_no}
 exit 1

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -17,7 +17,7 @@ ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
 # This step requires the 'github3.py' python module.
-git show # XXX debug
+git show HEAD # XXX debug
 pr_no=`git show HEAD | awk  '/(Merge #|Try #)/ {gsub(/ /, "", $2); gsub (/:/, "", $2); print substr($2, 1, length($2) - 1)}'`
 /opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py ${pr_no}
 exit 1

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -16,11 +16,8 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Patch the yk dependency if necessary.
-# This step requires the 'github3.py' python module.
-git show HEAD # XXX debug
-pr_no=`git show HEAD | awk  '/(Merge #|Try #)/ {gsub(/ /, "", $2); gsub (/:/, "", $2); print substr($2, 1, length($2) - 1)}'`
-/opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py ${pr_no}
-exit 1
+# This step requires the 'github3.py' and 'github2' Python modules.
+/opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py
 
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml --stage 2

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,6 +15,10 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
+# Patch the yk dependency if necessary.
+pr_no=`git show HEAD | awk '/(Merge #|Try #)/ {print substr($2, 2)}'`
+echo `python3 .buildbot_patch_yk_dep.py ${pr_no}`
+
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml --stage 2
 

--- a/.buildbot_patch_yk_dep.py
+++ b/.buildbot_patch_yk_dep.py
@@ -20,7 +20,7 @@ CARGO_TOML = "Cargo.toml"
 
 
 def get_pr_no():
-    repo = pygit2.Repository(".git")
+    repo = pygit2.Repository(".")
     walker = repo.walk(repo.head.target, pygit2.GIT_SORT_TOPOLOGICAL)
     commit = walker.__next__()
     line1 = commit.message.split('\n', maxsplit=1)[0].strip()

--- a/.buildbot_patch_yk_dep.py
+++ b/.buildbot_patch_yk_dep.py
@@ -60,7 +60,11 @@ if __name__ == "__main__":
     except ValueError:
         print(f"usage: {__file__} <pull-req-no>", file=sys.stderr)
         sys.exit(1)
-    url, branch = get_yk_branch(pr_no)
+
+    # As a sanity check that we correctly extracted the PR number from the
+    # bors merge commit, we leave the leading hash in and check it here.
+    assert(pr_no.startswith("#"))
+    url, branch = get_yk_branch(pr_no[1:])
 
     # x.py gets upset if you try to patch the dep to the default path:
     # "patch for `ykpack` in `https://github.com/softdevteam/yk` points to the

--- a/.buildbot_patch_yk_dep.py
+++ b/.buildbot_patch_yk_dep.py
@@ -1,0 +1,72 @@
+"""
+Checks the specified pull request description for a special `ci-yk` line and
+patches Config.toml if necessary.
+
+The line should be of the form:
+```
+ci-yk: <github-user> <branch>'
+```
+"""
+
+import sys
+import github3 as gh3
+
+SOFTDEV_USER = "softdevteam"
+YKRUSTC_REPO = "ykrustc"
+YK_REPO = "yk"
+DEFAULT_BRANCH = "master"
+CARGO_TOML = "Cargo.toml"
+
+
+def bogus_line():
+    print("couldn't parse 'ci-yk' line.", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_yk_branch(pr_no):
+    gh = gh3.GitHub()
+    issue = gh.issue(SOFTDEV_USER, YKRUSTC_REPO, pr_no)
+    issue.body += "\nci-yk: vext01 xxx"
+
+    # Look for a 'ci-yk' line in the body of the PR.
+    user = SOFTDEV_USER
+    branch = DEFAULT_BRANCH
+    for line in issue.body.splitlines():
+        line = line.strip()
+        if line.startswith("ci-yk:"):
+            elems = line.split(":")
+            if len(elems) != 2:
+                bogus_line()
+            else:
+                params = elems[1].strip().split()
+                if len(params) != 2:
+                    bogus_line()
+
+                user = params[0].strip()
+                branch = params[1].strip()
+                break
+    return f"https://github.com/{user}/{YK_REPO}", branch
+
+
+def write_cargo_toml(git_url, branch):
+    with open(CARGO_TOML, "a") as f:
+        f.write("\n[patch.'https://github.com/softdevteam/yk']\n")
+        f.write(f"ykpack = {{ git = '{git_url}', branch='{branch}' }}")
+
+
+if __name__ == "__main__":
+    try:
+        (_, pr_no) = sys.argv
+    except ValueError:
+        print(f"usage: {__file__} <pull-req-no>", file=sys.stderr)
+        sys.exit(1)
+    url, branch = get_yk_branch(pr_no)
+
+    # x.py gets upset if you try to patch the dep to the default path:
+    # "patch for `ykpack` in `https://github.com/softdevteam/yk` points to the
+    # same source, but patches must point to different sources"
+    if (url, branch) != (f"https://github.com/{SOFTDEV_USER}/{YK_REPO}",
+                         DEFAULT_BRANCH):
+        # For the sake of the CI logs, print the override.
+        print(f"Patching yk dependency to: {url} {branch}")
+        write_cargo_toml(url, branch)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,3 @@ backtrace = { path = "library/backtrace" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
-
-# When developing Yorick, you may find that you need to override ykpack. You
-# can do it once here, instead of all over the place, by uncommenting the
-# following two lines.
-#[patch."https://github.com/softdevteam/yk"]
-#ykpack = { path = "../yk/ykpack" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,3 +109,6 @@ backtrace = { path = "library/backtrace" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
+
+[patch.'https://github.com/softdevteam/yk']
+ykpack = { git = 'https://github.com/vext01/yk', branch='broken-branch' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,3 @@ backtrace = { path = "library/backtrace" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
-
-[patch.'https://github.com/softdevteam/yk']
-ykpack = { git = 'https://github.com/vext01/yk', branch='broken-branch' }


### PR DESCRIPTION
When doing a ykrustc pull request (PR), if the PR description contains a line
'yk-ci: <github-user> <branch>' then the `Cargo.toml` file is (temporarily)
patched to override the dependency.

Once the PR is merged, the `yk` branch should be merged immediately after.
We can't do that automatically unfortunately.

I'll test it in this PR now. I have a branch in my fork which I deliberately broke. If the override works, then the build should fail:

~~ci-yk: vext01 broken-branch~~