### PR TITLE
Patch the yk dep using a special line in the PR description.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,6 +15,10 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
+# Patch the yk dependency if necessary.
+# This step requires the 'github3.py' module.
+/opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py
+
 # Note that the gdb must be Python enabled.
 /usr/bin/time -v ./x.py test --config .buildbot.config.toml --stage 2
 

--- a/.buildbot_patch_yk_dep.py
+++ b/.buildbot_patch_yk_dep.py
@@ -1,0 +1,81 @@
+"""
+Checks the specified pull request description for a special `ci-yk` line and
+patches Config.toml if necessary.
+
+The line should be of the form:
+```
+ci-yk: <github-user> <branch>'
+```
+"""
+
+import sys
+import github3 as gh3
+import subprocess
+
+SOFTDEV_USER = "softdevteam"
+YKRUSTC_REPO = "ykrustc"
+YK_REPO = "yk"
+DEFAULT_BRANCH = "master"
+CARGO_TOML = "Cargo.toml"
+
+
+def get_pr_no():
+    # Get the first line of the commit.
+    proc = subprocess.run(["git", "log", "-1", "--pretty=format:%s"],
+                          capture_output=True, check=True)
+    line = proc.stdout.decode('utf-8')
+    assert line.startswith(('Merge #', 'Try #'))
+    pr_no = line.split(" ", maxsplit=1)[1]
+    pr_no = pr_no.rstrip(":")  # Colon present on 'Try' only it seems.
+    assert pr_no.startswith('#')
+    pr_no = int(pr_no[1:])
+    return pr_no
+
+
+def bogus_line():
+    print("couldn't parse 'ci-yk' line.", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_yk_branch(pr_no):
+    gh = gh3.GitHub()
+    issue = gh.issue(SOFTDEV_USER, YKRUSTC_REPO, pr_no)
+
+    # Look for a 'ci-yk' line in the body of the PR.
+    user = SOFTDEV_USER
+    branch = DEFAULT_BRANCH
+    for line in issue.body.splitlines():
+        line = line.strip()
+        if line.startswith("ci-yk:"):
+            elems = line.split(":")
+            if len(elems) != 2:
+                bogus_line()
+            else:
+                params = elems[1].strip().split()
+                if len(params) != 2:
+                    bogus_line()
+
+                user = params[0].strip()
+                branch = params[1].strip()
+                break
+    return f"https://github.com/{user}/{YK_REPO}", branch
+
+
+def write_cargo_toml(git_url, branch):
+    with open(CARGO_TOML, "a") as f:
+        f.write("\n[patch.'https://github.com/softdevteam/yk']\n")
+        f.write(f"ykpack = {{ git = '{git_url}', branch='{branch}' }}")
+
+
+if __name__ == "__main__":
+    pr_no = get_pr_no()
+    url, branch = get_yk_branch(pr_no)
+
+    # x.py gets upset if you try to patch the dep to the default path:
+    # "patch for `ykpack` in `https://github.com/softdevteam/yk` points to the
+    # same source, but patches must point to different sources"
+    if (url, branch) != (f"https://github.com/{SOFTDEV_USER}/{YK_REPO}",
+                         DEFAULT_BRANCH):
+        # For the sake of the CI logs, print the override.
+        print(f"Patching yk dependency to: {url} {branch}")
+        write_cargo_toml(url, branch)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,3 @@ backtrace = { path = "library/backtrace" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }
-
-# When developing Yorick, you may find that you need to override ykpack. You
-# can do it once here, instead of all over the place, by uncommenting the
-# following two lines.
-#[patch."https://github.com/softdevteam/yk"]
-#ykpack = { path = "../yk/ykpack" }


### PR DESCRIPTION
I got this working towards the end of last week. I think we can start the review now.

When doing a ykrustc pull request (PR), if the PR description contains a line`ci-yk: <github-user> <branch>` then the `Cargo.toml` file is (temporarily) patched to override the dependency.

Once a ykrustc PR is merged, the `yk` branch should be merged immediately after. We can't do that automatically unfortunately.

## Testing

I'll test this now by overriding the yk dependency to a branch I've deliberately broken.

~~ci-yk: vext01 broken-branch~~