### PR TITLE
CI prechecks

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,6 +15,9 @@ SNAP_DIR=/opt/ykrustc-bin-snapshots
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
+# Check for some common developer mistakes.
+/opt/buildbot/bin/python3 .buildbot_prechecks.py
+
 # Patch the yk dependency if necessary.
 # This step requires the 'github3.py' module.
 /opt/buildbot/bin/python3 .buildbot_patch_yk_dep.py

--- a/.buildbot_prechecks.py
+++ b/.buildbot_prechecks.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env/python3
+
+import sys
+import toml
+
+LOCK_FILE = "Cargo.lock"
+CARGO_TOML = "Cargo.toml"
+
+
+def check_lock_file(problems):
+    tml = toml.load(LOCK_FILE)
+
+    # The circular dependency on ykpack means that we can't always do CI in a
+    # manner where we have an up-to-date entry for ykpack in the lock file. We
+    # compromise: by ensuring it is absent, we force use of the newest ykpack
+    # in git.
+    for pkg in tml["package"]:
+        if pkg["name"] == "ykpack":
+            problems.append(f"ykpack detected in {LOCK_FILE}.")
+
+
+def check_cargo_toml(problems):
+    tml = toml.load(CARGO_TOML)
+
+    # During development it is commonplace to patch the ykpack dependency, but
+    # we don't ever want to accidentally commit this.
+    for patch in tml["patch"].keys():
+        if patch.endswith("/yk"):
+            problems.append(f"yk patching detected in {CARGO_TOML}.")
+
+
+def main():
+    problems = []
+    check_lock_file(problems)
+    check_cargo_toml(problems)
+
+    if problems:
+        print(f"{__file__}: the following problems were found:",
+              file=sys.stderr)
+        for pb in problems:
+            print(f" - {pb}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,15 +5655,3 @@ checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "ykpack"
-version = "0.1.0"
-source = "git+https://github.com/softdevteam/yk#204fa46244b291fafb597c0e1d2a68db2ef5b2fd"
-dependencies = [
- "bincode",
- "bitflags",
- "fallible-iterator",
- "fxhash",
- "serde",
-]


### PR DESCRIPTION
 Add a CI script to check for a couple of common mistakes:

 - Committing a yk patching in Cargo.toml.
 - Including ykpack in Cargo.lock.

All tested with forced builds from the web interface. Seems good to go!

