### PR TITLE
Pre-compute layout and offsets for `yk::Body`s.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -281,12 +281,13 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         }
     }
 
-    if let Some(sfcx) = fx.sir_func_cx {
+    if let Some(mut sfcx) = fx.sir_func_cx {
         // Often there are function declarations with no blocks. I think these are call targets
         // from other crates or compilation units, which have to be declared to keep LLVM happy.
         // There's no use in serialising these "empty functions" and they clash with the real
         // declarations.
         if !sfcx.is_empty() {
+            sfcx.compute_layout_and_offsets();
             cx.define_function_sir(sfcx.func);
         }
     }


### PR DESCRIPTION
In order to initialise the SIR interpreter for blackholing, we need to
allocate memory to hold all local declarations. Instead of computing the
space needed at run-time, which is slow, do it in the compilation phase.

Companion PR: https://github.com/softdevteam/yk/pull/183

ci-yk: ptersilie sir_layout