### PR TITLE
Remove map storing type layouts.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/sir.rs
+++ b/compiler/rustc_codegen_llvm/src/sir.rs
@@ -104,4 +104,10 @@ impl SirMethods for CodegenCx<'b, 'tcx> {
     fn define_function_sir(&self, sir: ykpack::Body) {
         self.sir.as_ref().unwrap().funcs.borrow_mut().push(sir);
     }
+
+    fn get_size_align(&self, tyid: ykpack::TypeId) -> (usize, usize) {
+        let types = self.sir.as_ref().unwrap().types.borrow();
+        let ty = types.get(tyid);
+        (ty.size, ty.align)
+    }
 }

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -287,7 +287,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         // There's no use in serialising these "empty functions" and they clash with the real
         // declarations.
         if !sfcx.is_empty() {
-            sfcx.compute_layout_and_offsets();
+            sfcx.compute_layout_and_offsets(&bx);
             cx.define_function_sir(sfcx.func);
         }
     }

--- a/compiler/rustc_codegen_ssa/src/traits/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/sir.rs
@@ -3,4 +3,5 @@ use ykpack;
 pub trait SirMethods {
     fn define_sir_type(&self, ty: ykpack::Ty) -> ykpack::TypeId;
     fn define_function_sir(&self, sir: ykpack::Body);
+    fn get_size_align(&self, tyid: ykpack::TypeId) -> (usize, usize);
 }


### PR DESCRIPTION
Since we now store size and alignments on the SIR types, we no longer
need the layout map to compute the memory layout for blackholing.