### PR TITLE
Temporary fix for CI

### DIFF
--- a/.buildbot.config.toml
+++ b/.buildbot.config.toml
@@ -12,6 +12,8 @@ tools = ["cargo", "rustdoc"]
 [llvm]
 assertions = true           # Turn on assertions in LLVM.
 
-[install]
-prefix = "build/ykrustc-stage2-latest"
-sysconfdir = "etc"
+# `x.py install` is currently broken.
+# https://github.com/rust-lang/rust/issues/80683
+#[install]
+#prefix = "build/ykrustc-stage2-latest"
+#sysconfdir = "etc"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -11,6 +11,7 @@ TARBALL_TOPDIR=`pwd`/build/ykrustc-stage2-latest
 TARBALL_NAME=ykrustc-${STD_TRACER_MODE}-stage2-${COMMIT_HASH}.tar.bz2
 SYMLINK_NAME=ykrustc-${STD_TRACER_MODE}-stage2-latest.tar.bz2
 SNAP_DIR=/opt/ykrustc-bin-snapshots
+PLATFORM_BUILD_DIR=build/x86_64-unknown-linux-gnu
 
 # Ensure the build fails if it uses excessive amounts of memory.
 ulimit -d $((1024 * 1024 * 10)) # 10 GiB
@@ -27,7 +28,12 @@ ulimit -d $((1024 * 1024 * 10)) # 10 GiB
 
 # Build extended tools and install into TARBALL_TOPDIR.
 mkdir -p ${TARBALL_TOPDIR}
-/usr/bin/time -v ./x.py install --config .buildbot.config.toml
+# `x.py install` is currently broken, so we use a workaround for now.
+# https://github.com/rust-lang/rust/issues/80683
+#/usr/bin/time -v ./x.py install --config .buildbot.config.toml
+/usr/bin/time -v ./x.py build --stage 2 --config .buildbot.config.toml library/std rustdoc cargo
+cp -r ${PLATFORM_BUILD_DIR}/stage2/* ${TARBALL_TOPDIR}
+cp -r ${PLATFORM_BUILD_DIR}/stage2-tools-bin/cargo ${TARBALL_TOPDIR}/bin
 
 # Archive the build and put it in /opt
 git show -s HEAD > ${TARBALL_TOPDIR}/VERSION


### PR DESCRIPTION
[`x.py install` seems to be broken at the moment](https://github.com/rust-lang/rust/issues/80683) and this in turn broke our CI. This branch proposes a workaround.

The first commit is the best "easy" fix I can come up with. I'd like this to be a temporary workaround, as it's not optimal: copying the stage 2 dir copies a lot more stuff than you'd find in a typical sysroot. We could try and remove the bits we don't need, but it's difficult to know what, and we'd have to keep it in sync with upstream. I'm hoping upstream will fix `x.py` install soon...

Tested on https://github.com/softdevteam/yk/pull/206. And [here](http://ci.soft-dev.org/#/builders/2/builds/527/steps/2/logs/stdio) is the forced build log.

The second commit allows us to run `.buildbot.sh` in scenarios where there isn't necessarily a bors merge commit on the top of the branch (i.e. during a manual or forced build). I needed this to test my changes and it seems generally useful.