### PR TITLE
Use MIR liveness analysis for SIR.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -440,12 +440,6 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         }
     }
 
-    fn push_sir_func(&self, func_cx: sir::SirFuncCx<'_>) {
-        if let Some(sir) = &self.sir {
-            sir.funcs.borrow_mut().push(func_cx.func);
-        }
-    }
-
     fn declare_c_main(&self, fn_type: Self::Type) -> Option<Self::Function> {
         if self.get_declared_value("main").is_none() {
             Some(self.declare_cfn("main", fn_type))

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1062,7 +1062,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     helper.maybe_sideeffect(self.mir, &mut bx, &[target]);
                 }
                 helper.funclet_br(self, &mut bx, target);
-                set_unimplemented_sir_term!(self, bb, terminator);
+                if let Some(sfcx) = &mut self.sir_func_cx {
+                    sfcx.set_term_goto(bb, target);
+                }
             }
 
             mir::TerminatorKind::SwitchInt { ref discr, switch_ty, ref targets } => {

--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -343,8 +343,14 @@ impl SirFuncCx<'tcx> {
             mir::StatementKind::Assign(box (ref place, ref rvalue)) => {
                 self.lower_assign_stmt(bx, bb, place, rvalue)
             }
-            // We compute our own liveness in Yorick, so these are ignored.
-            mir::StatementKind::StorageLive(_) | mir::StatementKind::StorageDead(_) => {}
+            mir::StatementKind::StorageLive(local) => {
+                let local = self.sir_local(bx, &local).local().unwrap();
+                self.push_stmt(bb, ykpack::Statement::StorageLive(local))
+            }
+            mir::StatementKind::StorageDead(local) => {
+                let local = self.sir_local(bx, &local).local().unwrap();
+                self.push_stmt(bb, ykpack::Statement::StorageDead(local))
+            }
             _ => self.push_stmt(bb, ykpack::Statement::Unimplemented(format!("{:?}", stmt))),
         }
     }

--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -313,6 +313,10 @@ impl SirFuncCx<'tcx> {
         self.set_terminator(bb, new_term);
     }
 
+    pub fn set_term_goto(&mut self, bb: mir::BasicBlock, target: mir::BasicBlock) {
+        self.set_terminator(bb.as_u32(), ykpack::Terminator::Goto(target.as_u32()));
+    }
+
     pub fn set_term_assert<Bx: BuilderMethods<'a, 'tcx>>(
         &mut self,
         bx: &Bx,

--- a/compiler/rustc_codegen_ssa/src/traits/misc.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/misc.rs
@@ -1,5 +1,4 @@
 use super::BackendTypes;
-use crate::sir::SirFuncCx;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::mir::mono::CodegenUnit;
 use rustc_middle::ty::{self, Instance, Ty};
@@ -20,7 +19,6 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn set_frame_pointer_elimination(&self, llfn: Self::Function);
     fn apply_target_cpu_attr(&self, llfn: Self::Function);
     fn create_used_variable(&self);
-    fn push_sir_func(&self, func_cx: SirFuncCx<'_>);
     /// Declares the extern "C" main function for the entry point. Returns None if the symbol already exists.
     fn declare_c_main(&self, fn_type: Self::Type) -> Option<Self::Function>;
 }


### PR DESCRIPTION
Companion PR to https://github.com/softdevteam/yk/pull/212.

We mainly need to lower `StorageLive` and `StorageDead` statements (a8192e0). But while we are here lower `Goto` statements too (c060199), which we'll be needing soon, and clean up an unused function (d9a696c).

ci-yk: ptersilie mir_liveness