### PR TITLE
Cater for changes to ykpack::TypeId.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/sir.rs
+++ b/compiler/rustc_codegen_llvm/src/sir.rs
@@ -43,7 +43,7 @@ pub fn write_sir<'tcx>(
     // The serialisation order matters here, as the load order (in the runtime) corresponds with
     // the type indices, hence use of `IndexMap` for insertion order.
     for (typ, typ_idx) in sir_types.map {
-        debug_assert!(usize::try_from(typ_idx).unwrap() == hdr.types.len());
+        debug_assert!(usize::try_from(typ_idx.0).unwrap() == hdr.types.len());
         hdr.types.push(encoder.tell());
         encoder.serialise(ykpack::Pack::Type(typ)).unwrap();
     }
@@ -98,7 +98,7 @@ pub fn write_sir<'tcx>(
 impl SirMethods for CodegenCx<'b, 'tcx> {
     fn define_sir_type(&self, ty: ykpack::Ty) -> ykpack::TypeId {
         let mut types = self.sir.as_ref().unwrap().types.borrow_mut();
-        (types.cgu_hash, types.index(ty))
+        ykpack::TypeId { cgu: types.cgu_hash, idx: types.index(ty) }
     }
 
     fn define_function_sir(&self, sir: ykpack::Body) {

--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -72,7 +72,7 @@ impl Sir {
             types: RefCell::new(SirTypes {
                 cgu_hash: ykpack::CguHash(cgu_hasher.finish()),
                 map: Default::default(),
-                next_idx: Default::default(),
+                next_idx: ykpack::TyIndex(0),
             }),
             funcs: Default::default(),
         }
@@ -931,17 +931,17 @@ impl SirTypes {
     /// Note that the index is only unique within the scope of the current compilation unit.
     /// To make a globally unique ID, we pair the index with CGU hash (see ykpack::CguHash).
     pub fn index(&mut self, t: ykpack::Ty) -> ykpack::TyIndex {
-        let next_idx = &mut self.next_idx;
+        let next_idx = &mut self.next_idx.0;
         *self.map.entry(t).or_insert_with(|| {
             let idx = *next_idx;
             *next_idx += 1;
-            idx
+            ykpack::TyIndex(idx)
         })
     }
 
     /// Given a type id return the corresponding type.
     pub fn get(&self, tyid: ykpack::TypeId) -> &ykpack::Ty {
-        self.map.get_index(usize::try_from(tyid.1).unwrap()).unwrap().0
+        self.map.get_index(usize::try_from(tyid.idx.0).unwrap()).unwrap().0
     }
 }
 


### PR DESCRIPTION
Cater for changes to ykpack::TypeId.

Companion to https://github.com/softdevteam/yk/pull/216

ci-yk: vext01 better-typeid