### PR TITLE
Reject closures marked #[interp_step].

### DIFF
--- a/compiler/rustc_codegen_ssa/src/sir.rs
+++ b/compiler/rustc_codegen_ssa/src/sir.rs
@@ -101,6 +101,18 @@ impl SirFuncCx<'tcx> {
                     );
                 }
 
+                let inst_kind = instance.ty(tcx, ty::ParamEnv::reveal_all()).kind();
+                if !matches!(inst_kind, ty::FnDef(..)) {
+                    // We reject anything that isn't a regular function to ensure that we don't
+                    // encounter odd problems elsewhere. For example, closures prepend an argument
+                    // for upvars which breaks the invariant that Local(1) is the interpreter
+                    // context.
+                    tcx.sess.span_fatal(
+                        tcx.def_span(instance.def_id()),
+                        "#[interp_step] can only be applied to regular function definitions",
+                    );
+                }
+
                 if mir.args_iter().count() != 1 {
                     tcx.sess.span_fatal(
                         tcx.def_span(instance.def_id()),

--- a/src/test/ui/yk/interp-step-closure.rs
+++ b/src/test/ui/yk/interp-step-closure.rs
@@ -1,0 +1,13 @@
+// build-fail
+// dont-check-compiler-stderr
+// compile-flags: -C tracer=hw -C opt-level=0
+
+#![feature(stmt_expr_attributes)]
+
+struct Ctx;
+
+fn main() {
+    let step = #[interp_step] |ctx: &mut Ctx| {};
+    //~^ #[interp_step] can only be applied to regular function definitions
+    step(&mut Ctx);
+}


### PR DESCRIPTION
I was investigating ways of parametrising tests. One way involved passing variants of the interpreter step as closures. I found out the hard way that this won't work.

We can't accept closures, as these have a hidden argument prepended for the upvars and this breaks the invariant that Local(1) is the interpreter context.

This change causes ykrustc to reject a program that marks a closure `#[interp_step]`.