### PR TITLE
Update builder name.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 # The service providing the commit statuses to GitHub.
-status = ["buildbot/yorick-buildbot-build-script-hw"]
+status = ["buildbot/yk-buildbot-build-script-hw"]
 
 # Allow eight hours for builds + tests.
 timeout_sec = 28800


### PR DESCRIPTION
I don't know if we will need this repo moving forward, but might as well update the CI config so that we won't be baffled in the future.